### PR TITLE
Add bulk upload

### DIFF
--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -537,7 +537,13 @@ const queries = {
     template: `
       query GetBatch($id: String!) {
         batch(_id: $id) {
-            _id
+          _id
+          eTag
+          processingStart
+          processingEnd
+          dead
+          remaining
+          total
         }
       }
     `,

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -544,6 +544,9 @@ const queries = {
           dead
           remaining
           total
+          errors {
+            error
+          }
         }
       }
     `,

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -498,8 +498,42 @@ const queries = {
         }
       }
     `
-  })
+  }),
 
+  getBatches: () => ({
+    template: `
+      query GetBatches($input: QueryBatchesInput!) {
+        batches(input: $input) {
+          pageInfo {
+            previous
+            hasPrevious
+            next
+            hasNext
+          },
+          batches {
+            _id
+            eTag
+            processingStart
+            processingEnd
+            remaining
+            total
+          }
+        }
+      }
+    `,
+    variables: { input: {} }
+  }),
+
+  getBatch: ({ id }) => ({
+    template: `
+      query GetBatch($id: String!) {
+        batch(_id: $id) {
+            _id
+        }
+      }
+    `,
+    variables: { id }
+  })
 };
 
 export default queries;

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -490,6 +490,16 @@ const queries = {
     variables: { input: input },
   }),
 
+  getSignedUrl: () => ({
+    template: `
+      mutation CreateUpload {
+        createUpload {
+          url
+        }
+      }
+    `
+  })
+
 };
 
 export default queries;

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -503,7 +503,7 @@ const queries = {
     variables: { input }
   }),
 
-  getBatches: () => ({
+  getBatches: (input) => ({
     template: `
       query GetBatches($input: QueryBatchesInput!) {
         batches(input: $input) {
@@ -520,11 +520,12 @@ const queries = {
             processingEnd
             remaining
             total
+            originalFile
           }
         }
       }
     `,
-    variables: { input: {} }
+    variables: { input }
   }),
 
   getBatch: ({ id }) => ({

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -503,7 +503,7 @@ const queries = {
     variables: { input }
   }),
 
-  getBatches: (input) => ({
+  getBatches: ({user, pageInfo, page}) => ({
     template: `
       query GetBatches($input: QueryBatchesInput!) {
         batches(input: $input) {
@@ -525,7 +525,12 @@ const queries = {
         }
       }
     `,
-    variables: { input }
+    variables: { input: {
+      ...(page === 'next' && { next: pageInfo.next }),
+      ...(page === 'previous' && { previous: pageInfo.previous }),
+      limit: 5,
+      user
+    } }
   }),
 
   getBatch: ({ id }) => ({

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -548,6 +548,17 @@ const queries = {
       }
     `,
     variables: { id }
+  }),
+
+  stopBatch: ({ id }) => ({
+    template: `
+      mutation StopBatch($input: StopBatchInput!) {
+        stopBatch(input: $input) {
+          message
+        }
+      }
+    `,
+    variables: { input: { batch: id } }
   })
 };
 

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -490,14 +490,17 @@ const queries = {
     variables: { input: input },
   }),
 
-  getSignedUrl: () => ({
+  getSignedUrl: (input) => ({
     template: `
-      mutation CreateUpload {
-        createUpload {
-          url
+      mutation CreateUpload($input: CreateUploadInput!) {
+        createUpload(input: $input) {
+            batch
+            user
+            url
         }
       }
-    `
+    `,
+    variables: { input }
   }),
 
   getBatches: () => ({

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -84,6 +84,7 @@ const App = () => {
       const idToken = user.signInUserSession.idToken.payload;
       payload.username = idToken['cognito:username'];
       payload.groups = idToken['cognito:groups'];
+      payload.aud = idToken['aud'];
     }
     dispatch(userAuthStateChanged(payload));
   }, [user, authStatus, dispatch]);

--- a/src/app/rootReducer.js
+++ b/src/app/rootReducer.js
@@ -9,6 +9,7 @@ import reviewReducer from '../features/review/reviewSlice';
 import loupeReducer from '../features/loupe/loupeSlice';
 import projectReducer from '../features/projects/projectsSlice';
 import trackingReducer from '../features/tracking/trackingSlice';
+import uploadReducer from '../features/upload/uploadSlice';
 
 const createRootReducer = (history) => combineReducers({
   router: connectRouter(history),
@@ -21,6 +22,7 @@ const createRootReducer = (history) => combineReducers({
   loupe: loupeReducer,
   undoHistory: undoHistoryReducer, 
   tracking: trackingReducer,
+  uploads: uploadReducer,
 });
 
 export default createRootReducer;

--- a/src/assets/fontawesome.js
+++ b/src/assets/fontawesome.js
@@ -26,6 +26,7 @@ import {
   faPen,
   faSync,
   faExclamation,
+  faUpload
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -54,5 +55,6 @@ library.add(
   faCamera,
   faPen,
   faSync,
-  faExclamation
+  faExclamation,
+  faUpload
 );

--- a/src/auth/roles.js
+++ b/src/auth/roles.js
@@ -11,7 +11,6 @@ export const WRITE_AUTOMATION_RULES_ROLES =     [MANAGER];
 export const WRITE_CAMERA_REGISTRATION_ROLES =  [MANAGER];
 export const QUERY_WITH_CUSTOM_FILTER =         [MANAGER];
 export const READ_STATS_ROLES =                 [MANAGER];
-export const BULK_UPLOAD_ROLES =                [MANAGER];
 
 export const hasRole = (currRoles, targetRoles = []) => (
   currRoles && currRoles.some((role) => targetRoles.includes(role))

--- a/src/auth/roles.js
+++ b/src/auth/roles.js
@@ -11,6 +11,7 @@ export const WRITE_AUTOMATION_RULES_ROLES =     [MANAGER];
 export const WRITE_CAMERA_REGISTRATION_ROLES =  [MANAGER];
 export const QUERY_WITH_CUSTOM_FILTER =         [MANAGER];
 export const READ_STATS_ROLES =                 [MANAGER];
+export const BULK_UPLOAD_ROLES =                [MANAGER];
 
 export const hasRole = (currRoles, targetRoles = []) => (
   currRoles && currRoles.some((role) => targetRoles.includes(role))

--- a/src/components/HydratedModal.js
+++ b/src/components/HydratedModal.js
@@ -8,6 +8,7 @@ import CameraAdminModal from '../features/cameras/CameraAdminModal';
 import AutomationRulesForm from '../features/projects/AutomationRulesForm';
 import SaveViewForm from '../features/projects/SaveViewForm';
 import DeleteViewForm from '../features/projects/DeleteViewForm';
+import BulkUploadForm from '../features/projects/BulkUploadForm';
 import { clearExport, clearStats } from '../features/images/imagesSlice';
 import {
   selectModalOpen,
@@ -60,6 +61,12 @@ const HydratedModal = () => {
       title: 'Delete View',
       size: 'sm',
       content: <DeleteViewForm/>,
+      callBackOnClose: () => true,
+    },
+    'bulk-upload-form': {
+      title: 'Bulk upload',
+      size: 'md',
+      content: <BulkUploadForm/>,
       callBackOnClose: () => true,
     },
   };

--- a/src/components/HydratedModal.js
+++ b/src/components/HydratedModal.js
@@ -8,7 +8,7 @@ import CameraAdminModal from '../features/cameras/CameraAdminModal';
 import AutomationRulesForm from '../features/projects/AutomationRulesForm';
 import SaveViewForm from '../features/projects/SaveViewForm';
 import DeleteViewForm from '../features/projects/DeleteViewForm';
-import BulkUploadForm from '../features/projects/BulkUploadForm';
+import BulkUploadForm from '../features/upload/BulkUploadForm';
 import { clearExport, clearStats } from '../features/images/imagesSlice';
 import {
   selectModalOpen,

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -1,0 +1,18 @@
+import { styled } from '@stitches/react';
+import { indigo } from '@radix-ui/colors';
+
+const ProgressBar = styled('progress', {
+  width: '100%',
+  backgroundColor: indigo.indigo5,
+  '&::-moz-progress-bar': {
+    backgroundColor: indigo.indigo11,
+  },
+  '&::-webkit-progress-bar': {
+    backgroundColor: indigo.indigo5,
+  },
+  '&::-webkit-progress-value': {
+    backgroundColor: indigo.indigo11,
+  }
+});
+
+export default ProgressBar;

--- a/src/features/projects/BulkUploadForm.js
+++ b/src/features/projects/BulkUploadForm.js
@@ -1,17 +1,22 @@
 import React from 'react';
-import { Formik, Form, Field } from 'formik';
+import { useDispatch, useSelector } from 'react-redux';
+import { Formik, Form } from 'formik';
 import { FormWrapper, ButtonRow, HelperText, FormError } from '../../components/Form';
 import * as Yup from 'yup';
 import Button from '../../components/Button';
+import ProgressBar from '../../components/ProgressBar';
+import { uploadFile, selectUploadsLoading } from './projectsSlice';
 
 const bulkUploadSchema = Yup.object().shape({
   images_zip: Yup.mixed().required('File is required'),
 });
 
 const BulkUploadForm = ({ handleClose }) => {
-  const handleSubmit = () => {
-    console.log('submitting')
-  }
+  const { isLoading, progress } = useSelector(selectUploadsLoading);
+  const percentUploaded = Math.round(progress * 100);
+  const dispatch = useDispatch();
+
+  const handleSubmit = (values) => dispatch(uploadFile(values));
 
   return (
     <div>
@@ -19,26 +24,31 @@ const BulkUploadForm = ({ handleClose }) => {
         <Formik
           onSubmit={(values) => handleSubmit(values)}
           validationSchema={bulkUploadSchema}
-          initialValues={{ images_zip: '' }}
+          initialValues={{ images_zip: null }}
         >
-          {({ errors, touched, values }) => (
+          {({ errors, touched, values, setFieldValue }) => (
             <Form>
               <HelperText>
                 Upload a ZIP file containing images for bulk processing
               </HelperText>
 
-              <Field
+              <input
                 type='file'
+                id='images_zip'
                 name='images_zip'
                 accept='.zip'
-                value={values.images_zip}
+                onChange={(e) => setFieldValue('images_zip', e.target.files[0])}
               />
               {touched.images_zip && errors.images_zip && (
                 <FormError>{ errors.images_zip }</FormError>
               )}
 
+              {(isLoading || progress > 0) && (
+                <ProgressBar aria-label="Upload progress" max="100" value={percentUploaded}>{percentUploaded}%</ProgressBar>
+              )}
+
               <ButtonRow>
-                <Button type='submit' size='large'>
+                <Button type='submit' size='large' disabled={isLoading}>
                   Upload
                 </Button>
               </ButtonRow>

--- a/src/features/projects/BulkUploadForm.js
+++ b/src/features/projects/BulkUploadForm.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Formik, Form, Field } from 'formik';
+import { FormWrapper, ButtonRow, HelperText, FormError } from '../../components/Form';
+import * as Yup from 'yup';
+import Button from '../../components/Button';
+
+const bulkUploadSchema = Yup.object().shape({
+  images_zip: Yup.mixed().required('File is required'),
+});
+
+const BulkUploadForm = ({ handleClose }) => {
+  const handleSubmit = () => {
+    console.log('submitting')
+  }
+
+  return (
+    <div>
+      <FormWrapper>
+        <Formik
+          onSubmit={(values) => handleSubmit(values)}
+          validationSchema={bulkUploadSchema}
+          initialValues={{ images_zip: '' }}
+        >
+          {({ errors, touched, values }) => (
+            <Form>
+              <HelperText>
+                Upload a ZIP file containing images for bulk processing
+              </HelperText>
+
+              <Field
+                type='file'
+                name='images_zip'
+                accept='.zip'
+                value={values.images_zip}
+              />
+              {touched.images_zip && errors.images_zip && (
+                <FormError>{ errors.images_zip }</FormError>
+              )}
+
+              <ButtonRow>
+                <Button type='submit' size='large'>
+                  Upload
+                </Button>
+              </ButtonRow>
+            </Form>
+          )}
+        </Formik>
+      </FormWrapper>
+    </div>
+  )
+}
+
+export default BulkUploadForm;

--- a/src/features/projects/SidebarNav.js
+++ b/src/features/projects/SidebarNav.js
@@ -105,7 +105,7 @@ const SidebarNav = ({ view, toggleFiltersPanel, filtersPanelOpen }) => {
       }
 
       {/* bulk upload view */}
-      {hasRole(userRoles, BULK_UPLOAD_ROLES) &&
+      {/* {hasRole(userRoles, BULK_UPLOAD_ROLES) && */}
         <SidebarNavItem 
           state={modalOpen && (modalContent === 'bulk-upload-form') ? 'active' : ''}
           disabled={!selectedProject}
@@ -113,7 +113,7 @@ const SidebarNav = ({ view, toggleFiltersPanel, filtersPanelOpen }) => {
           icon={<FontAwesomeIcon icon={['fas', 'upload']} />}
           tooltipContent='Bulk upload images'
         />
-      }
+      {/* } */}
 
     </StyledSidebarNav>
   );

--- a/src/features/projects/SidebarNav.js
+++ b/src/features/projects/SidebarNav.js
@@ -5,7 +5,7 @@ import {
   hasRole,
   WRITE_AUTOMATION_RULES_ROLES,
   WRITE_VIEWS_ROLES,
-  BULK_UPLOAD_ROLES,
+  WRITE_IMAGES_ROLES,
 } from '../../auth/roles';
 import { styled } from '../../theme/stitches.config.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -105,7 +105,7 @@ const SidebarNav = ({ view, toggleFiltersPanel, filtersPanelOpen }) => {
       }
 
       {/* bulk upload view */}
-      {/* {hasRole(userRoles, BULK_UPLOAD_ROLES) && */}
+      {hasRole(userRoles, WRITE_IMAGES_ROLES) &&
         <SidebarNavItem 
           state={modalOpen && (modalContent === 'bulk-upload-form') ? 'active' : ''}
           disabled={!selectedProject}
@@ -113,7 +113,7 @@ const SidebarNav = ({ view, toggleFiltersPanel, filtersPanelOpen }) => {
           icon={<FontAwesomeIcon icon={['fas', 'upload']} />}
           tooltipContent='Bulk upload images'
         />
-      {/* } */}
+      }
 
     </StyledSidebarNav>
   );

--- a/src/features/projects/SidebarNav.js
+++ b/src/features/projects/SidebarNav.js
@@ -5,6 +5,7 @@ import {
   hasRole,
   WRITE_AUTOMATION_RULES_ROLES,
   WRITE_VIEWS_ROLES,
+  BULK_UPLOAD_ROLES,
 } from '../../auth/roles';
 import { styled } from '../../theme/stitches.config.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -102,6 +103,15 @@ const SidebarNav = ({ view, toggleFiltersPanel, filtersPanelOpen }) => {
           tooltipContent='Delete view'
         />
       }
+
+      {/* bulk upload view */}
+      <SidebarNavItem 
+        state={modalOpen && (modalContent === 'bulk-upload-form') ? 'active' : ''}
+        disabled={!selectedProject}
+        handleClick={() => handleModalToggle('bulk-upload-form')}
+        icon={<FontAwesomeIcon icon={['fas', 'upload']} />}
+        tooltipContent='Bulk upload images'
+      />
 
     </StyledSidebarNav>
   );

--- a/src/features/projects/SidebarNav.js
+++ b/src/features/projects/SidebarNav.js
@@ -105,13 +105,15 @@ const SidebarNav = ({ view, toggleFiltersPanel, filtersPanelOpen }) => {
       }
 
       {/* bulk upload view */}
-      <SidebarNavItem 
-        state={modalOpen && (modalContent === 'bulk-upload-form') ? 'active' : ''}
-        disabled={!selectedProject}
-        handleClick={() => handleModalToggle('bulk-upload-form')}
-        icon={<FontAwesomeIcon icon={['fas', 'upload']} />}
-        tooltipContent='Bulk upload images'
-      />
+      {hasRole(userRoles, BULK_UPLOAD_ROLES) &&
+        <SidebarNavItem 
+          state={modalOpen && (modalContent === 'bulk-upload-form') ? 'active' : ''}
+          disabled={!selectedProject}
+          handleClick={() => handleModalToggle('bulk-upload-form')}
+          icon={<FontAwesomeIcon icon={['fas', 'upload']} />}
+          tooltipContent='Bulk upload images'
+        />
+      }
 
     </StyledSidebarNav>
   );

--- a/src/features/projects/projectsSlice.js
+++ b/src/features/projects/projectsSlice.js
@@ -47,28 +47,6 @@ export const projectsSlice = createSlice({
   name: 'projects',
   initialState,
   reducers: {
-    uploadStart: (state) => {
-      const ls = { isLoading: true, operation: 'uploading', errors: null, progress: 0 };
-      state.loadingStates.uploads = ls;
-    },
-
-    uploadFailure: (state, { payload }) => {
-      const ls = { isLoading: false, operation: null, errors: payload, progress: 0 };  
-      state.loadingStates.uploads = ls;
-    },
-
-    uploadSuccess: (state, { payload }) => {
-      const { progress } = state.loadingStates.uploads
-      const ls = { isLoading: false, operation: null, errors: null, progress };
-      state.loadingStates.uploads = ls;
-    },
-
-    uploadProgress: (state, { payload }) => {
-      console.log(payload.progress)
-      const ls = { isLoading: true, operation: 'uploading', errors: null, progress: payload.progress };
-      state.loadingStates.uploads = ls;
-    },
-
     getProjectsStart: (state) => {
       const ls = { isLoading: true, operation: 'fetching', errors: null };
       state.loadingStates.projects = ls;
@@ -271,11 +249,6 @@ export const {
   setUnsavedViewChanges,
   dismissProjectsError,
 
-  uploadStart,
-  uploadSuccess,
-  uploadFailure,
-  uploadProgress,
-
   editViewStart,
   saveViewSuccess,
   deleteViewSuccess,
@@ -315,39 +288,6 @@ export const fetchProjects = () => async dispatch => {
     dispatch(getProjectsFailure(err));
   }
 };
-
-// bulk upload thunk
-export const uploadFile = (payload) => async dispatch => {
-  try {
-    dispatch(uploadStart());
-    // TODO: get signed URL
-    const signedUrl = 'https://ae03e36e-3454-4e5e-a4e8-1afe525c0019.mock.pstmn.io/file-upload'; 
-
-    var data = new FormData()
-    data.append('images_zip', payload.images_zip)
-
-    const xhr = new XMLHttpRequest();
-    await new Promise((resolve) => {
-      xhr.upload.addEventListener("progress", (event) => {
-        if (event.lengthComputable) {
-          dispatch(uploadProgress({ progress: event.loaded / event.total }))
-        }
-      });
-      xhr.addEventListener("loadend", () => {
-        resolve(xhr.readyState === 4 && xhr.status === 200);
-      });
-      // TODO: use signed URL
-      xhr.open('POST', signedUrl, true);
-      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
-      xhr.send(data);
-    })
-
-    dispatch(uploadSuccess());
-  } catch (err) {
-    console.log('err: ', err)
-    dispatch(uploadFailure(err))
-  }
-}
 
 // editView thunk
 // TODO: maybe break this up into discrete thunks?
@@ -501,7 +441,6 @@ export const selectMLModels = createSelector([selectSelectedProject],
   (proj) => proj ? proj.mlModels : null
 );
 export const selectProjectsLoading = state => state.projects.loadingStates.projects;
-export const selectUploadsLoading = state => state.projects.loadingStates.uploads;
 export const selectViewsLoading = state => state.projects.loadingStates.views;
 export const selectDeploymentsLoading = state => state.projects.loadingStates.deployments;
 export const selectModelsLoadingState = state => state.projects.loadingStates.models;

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -5,14 +5,14 @@ import { FormWrapper, ButtonRow, HelperText, FormError } from '../../components/
 import * as Yup from 'yup';
 import Button from '../../components/Button';
 import ProgressBar from '../../components/ProgressBar';
-import { uploadFile, selectUploadsLoading } from './projectsSlice';
+import { uploadFile, selectUploadsLoading } from './uploadSlice';
 
 const bulkUploadSchema = Yup.object().shape({
   images_zip: Yup.mixed().required('File is required'),
 });
 
 const BulkUploadForm = ({ handleClose }) => {
-  const { isLoading, progress } = useSelector(selectUploadsLoading);
+  const { isLoading, progress }  = useSelector(selectUploadsLoading);
   const percentUploaded = Math.round(progress * 100);
   const dispatch = useDispatch();
 

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -5,7 +5,7 @@ import { FormWrapper, ButtonRow, HelperText, FormError } from '../../components/
 import * as Yup from 'yup';
 import Button from '../../components/Button';
 import ProgressBar from '../../components/ProgressBar';
-import { uploadFile, selectUploadsLoading, fetchBatches, selectBatchStates } from './uploadSlice';
+import { uploadFile, selectUploadsLoading, fetchBatches, selectBatchStates, selectBatchPageInfo } from './uploadSlice';
 import { styled } from '@stitches/react';
 
 const bulkUploadSchema = Yup.object().shape({
@@ -15,10 +15,10 @@ const bulkUploadSchema = Yup.object().shape({
 const Table = styled('table', {
   borderSpacing: '0',
   width: '100%',
-  marginBottom: '30px'
+  marginBottom: '15px'
 })
 
-const TableHead = styled('th', {
+const TableHeadCell = styled('th', {
   textAlign: 'left',
   verticalAlign: 'bottom',
   padding: '5px 15px',
@@ -35,9 +35,18 @@ const TableCell = styled('td', {
   verticalAlign: 'top',
 });
 
+const Pagination = styled('div', {
+  textAlign: 'right',
+  marginBottom: '30px',
+  '& > button': {
+    marginLeft: '10px'
+  }
+})
+
 const BulkUploadForm = ({ handleClose }) => {
   const { isLoading, progress }  = useSelector(selectUploadsLoading);
   const batchStates = useSelector(selectBatchStates);
+  const { hasNext, hasPrevious } = useSelector(selectBatchPageInfo);
   const percentUploaded = Math.round(progress * 100);
   const dispatch = useDispatch();
 
@@ -62,8 +71,8 @@ const BulkUploadForm = ({ handleClose }) => {
       <Table>
         <thead>
           <tr>
-            <TableHead>File name</TableHead>
-            <TableHead>Status</TableHead>
+            <TableHeadCell>File name</TableHeadCell>
+            <TableHeadCell>Status</TableHeadCell>
           </tr>
         </thead>
         <tbody>
@@ -86,6 +95,10 @@ const BulkUploadForm = ({ handleClose }) => {
           )}
         </tbody>
       </Table>
+      <Pagination>
+        {hasPrevious && <Button size='small' onClick={() => dispatch(fetchBatches('previous'))}>Previous page</Button>}
+        {hasNext && <Button size='small' onClick={() => dispatch(fetchBatches('next'))}>Next page</Button>}
+      </Pagination>
 
       <FormWrapper>
         <Formik

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -14,6 +14,8 @@ const bulkUploadSchema = Yup.object().shape({
 
 const Table = styled('table', {
   borderSpacing: '0',
+  width: '100%',
+  marginBottom: '30px'
 })
 
 const TableHead = styled('th', {
@@ -60,24 +62,25 @@ const BulkUploadForm = ({ handleClose }) => {
       <Table>
         <thead>
           <tr>
-            <TableHead>ID</TableHead>
-            <TableHead>Process start</TableHead>
-            <TableHead>Process end</TableHead>
-            <TableHead>Total images</TableHead>
-            <TableHead>Remaining images</TableHead>
+            <TableHead>File name</TableHead>
+            <TableHead>Status</TableHead>
           </tr>
         </thead>
         <tbody>
-          {sortedBatchStates.map(({ _id, eTag, processingStart, processingEnd, total, remaining }) => {
-            const start = new Date(parseInt(processingStart)).toLocaleString();
-            const end = processingEnd && new Date(parseInt(processingEnd)).toLocaleString();
+          {sortedBatchStates.map(({ _id, originalFile, processingStart, processingEnd, total, remaining }) => {
+            let status = 'Queued'
+            if (processingStart) {
+              const dateString = new Date(parseInt(processingStart)).toLocaleString();
+              status = `Processing since ${dateString}. ${total ? `Finsished ${total - remaining} of ${total} images.` : ''}`
+            }
+            if (processingEnd) {
+              const dateString = new Date(parseInt(processingEnd)).toLocaleString();
+              status = `Processing of ${total} images finsihed at ${dateString}.`
+            }
             return (
               <TableRow key={_id}>
-                <TableCell>{eTag}</TableCell>
-                <TableCell>{start}</TableCell>
-                <TableCell>{end}</TableCell>
-                <TableCell>{total}</TableCell>
-                <TableCell>{remaining}</TableCell>
+                <TableCell>{originalFile}</TableCell>
+                <TableCell>{status}</TableCell>
               </TableRow>
             )}
           )}
@@ -92,9 +95,8 @@ const BulkUploadForm = ({ handleClose }) => {
         >
           {({ errors, touched, values, setFieldValue }) => (
             <Form>
-              <h2>Upload new batch</h2>
               <HelperText>
-                Upload a ZIP file containing images for bulk processing
+                <b>Upload a ZIP file containing images for bulk processing</b>
               </HelperText>
 
               <input

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -47,7 +47,12 @@ const BulkUploadForm = ({ handleClose }) => {
   const handleSubmit = (values) => dispatch(uploadFile({ file: values.images_zip }));
 
   useEffect(() => {
-    dispatch(fetchBatches())
+    // Initially loaded the batches
+    dispatch(fetchBatches());
+
+    // Update batches every minute
+    const intervalID = setInterval(() => dispatch(fetchBatches()), 60000);
+    return () => clearInterval(intervalID);
   }, [dispatch]);
 
   return (

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -80,7 +80,10 @@ const BulkUploadForm = ({ handleClose }) => {
             let status = 'Queued'
             if (processingStart) {
               const dateString = new Date(parseInt(processingStart)).toLocaleString();
-              status = `Processing since ${dateString}. ${total ? `Finished ${total - remaining} of ${total} images.` : ''}`
+              status = `Processing started at ${dateString}.`
+              if (remaining !== null) {
+                status = `${status} ${total ? `Finished ${total - remaining} of ${total} images.` : ''} ${total - remaining === 0 ? 'Wrapping up.' : ''}`
+              }
             }
             if (processingEnd) {
               const dateString = new Date(parseInt(processingEnd)).toLocaleString();

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Formik, Form } from 'formik';
 import { FormWrapper, ButtonRow, HelperText, FormError } from '../../components/Form';
 import * as Yup from 'yup';
 import Button from '../../components/Button';
 import ProgressBar from '../../components/ProgressBar';
-import { uploadFile, selectUploadsLoading } from './uploadSlice';
+import { uploadFile, selectUploadsLoading, fetchBatches, selectBatchStates } from './uploadSlice';
 
 const bulkUploadSchema = Yup.object().shape({
   images_zip: Yup.mixed().required('File is required'),
@@ -13,13 +13,49 @@ const bulkUploadSchema = Yup.object().shape({
 
 const BulkUploadForm = ({ handleClose }) => {
   const { isLoading, progress }  = useSelector(selectUploadsLoading);
+  const batchStates = useSelector(selectBatchStates);
   const percentUploaded = Math.round(progress * 100);
   const dispatch = useDispatch();
 
+  const sortedBatchStates = useMemo(() => {
+    const clonedStates = batchStates.slice();
+    return clonedStates.sort((a, b) => parseInt(b.processingStart) - parseInt(a.processingStart))
+  }, [batchStates]);
+
   const handleSubmit = (values) => dispatch(uploadFile({ file: values.images_zip }));
+
+  useEffect(() => {
+    dispatch(fetchBatches())
+  }, [dispatch]);
 
   return (
     <div>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Process start</th>
+            <th>Process end</th>
+            <th>Total images</th>
+            <th>Remaining images</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedBatchStates.map(({ _id, eTag, processingStart, processingEnd, total, remaining }) => {
+            const start = new Date(parseInt(processingStart)).toLocaleString();
+            const end = processingEnd && new Date(parseInt(processingEnd)).toLocaleString();
+            return (
+              <tr key={_id}>
+                <td>{eTag}</td>
+                <td>{start}</td>
+                <td>{end}</td>
+                <td>{total}</td>
+                <td>{remaining}</td>
+              </tr>
+            )}
+          )}
+        </tbody>
+      </table>
       <FormWrapper>
         <Formik
           onSubmit={(values) => handleSubmit(values)}
@@ -28,6 +64,7 @@ const BulkUploadForm = ({ handleClose }) => {
         >
           {({ errors, touched, values, setFieldValue }) => (
             <Form>
+              <h2>Upload new batch</h2>
               <HelperText>
                 Upload a ZIP file containing images for bulk processing
               </HelperText>

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -9,7 +9,12 @@ import { uploadFile, selectUploadsLoading, fetchBatches, selectBatchStates, sele
 import { styled } from '@stitches/react';
 
 const bulkUploadSchema = Yup.object().shape({
-  images_zip: Yup.mixed().required('File is required'),
+  images_zip: Yup
+    .mixed()
+    .required('File is required')
+    .test('fileSize', 'The file must be smaller than 50GB.', (value) => {
+      return value.size <= Math.pow(1024, 3) * 50;
+    }),
 });
 
 const Table = styled('table', {

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -80,11 +80,11 @@ const BulkUploadForm = ({ handleClose }) => {
             let status = 'Queued'
             if (processingStart) {
               const dateString = new Date(parseInt(processingStart)).toLocaleString();
-              status = `Processing since ${dateString}. ${total ? `Finsished ${total - remaining} of ${total} images.` : ''}`
+              status = `Processing since ${dateString}. ${total ? `Finished ${total - remaining} of ${total} images.` : ''}`
             }
             if (processingEnd) {
               const dateString = new Date(parseInt(processingEnd)).toLocaleString();
-              status = `Processing of ${total} images finsihed at ${dateString}.`
+              status = `Processing of ${total} images finished at ${dateString}.`
             }
             return (
               <TableRow key={_id}>

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -5,7 +5,7 @@ import { FormWrapper, ButtonRow, HelperText, FormError } from '../../components/
 import * as Yup from 'yup';
 import Button from '../../components/Button';
 import ProgressBar from '../../components/ProgressBar';
-import { uploadFile, selectUploadsLoading, fetchBatches, selectBatchStates, selectBatchPageInfo } from './uploadSlice';
+import { uploadFile, selectUploadsLoading, fetchBatches, selectBatchStates, selectBatchPageInfo, stopBatch } from './uploadSlice';
 import { styled } from '@stitches/react';
 
 const bulkUploadSchema = Yup.object().shape({
@@ -73,11 +73,14 @@ const BulkUploadForm = ({ handleClose }) => {
           <tr>
             <TableHeadCell>File name</TableHeadCell>
             <TableHeadCell>Status</TableHeadCell>
+            <TableHeadCell>Actions</TableHeadCell>
           </tr>
         </thead>
         <tbody>
           {sortedBatchStates.map(({ _id, originalFile, processingStart, processingEnd, total, remaining }) => {
             let status = 'Queued'
+            const isStopable = !processingEnd && (remaining === null || total - remaining > 0);
+
             if (processingStart) {
               const dateString = new Date(parseInt(processingStart)).toLocaleString();
               status = `Processing started at ${dateString}.`
@@ -93,6 +96,7 @@ const BulkUploadForm = ({ handleClose }) => {
               <TableRow key={_id}>
                 <TableCell>{originalFile}</TableCell>
                 <TableCell>{status}</TableCell>
+                <TableCell>{isStopable && <Button size='small' onClick={() => dispatch(stopBatch(_id))}>Stop</Button>}</TableCell>
               </TableRow>
             )}
           )}

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -43,7 +43,7 @@ const Pagination = styled('div', {
   }
 })
 
-const Status = styled('p');
+const Status = styled('span');
 const Error = styled('span', {
   color: 'red'
 });

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -16,7 +16,7 @@ const BulkUploadForm = ({ handleClose }) => {
   const percentUploaded = Math.round(progress * 100);
   const dispatch = useDispatch();
 
-  const handleSubmit = (values) => dispatch(uploadFile(values));
+  const handleSubmit = (values) => dispatch(uploadFile({ file: values.images_zip }));
 
   return (
     <div>

--- a/src/features/upload/BulkUploadForm.js
+++ b/src/features/upload/BulkUploadForm.js
@@ -6,9 +6,31 @@ import * as Yup from 'yup';
 import Button from '../../components/Button';
 import ProgressBar from '../../components/ProgressBar';
 import { uploadFile, selectUploadsLoading, fetchBatches, selectBatchStates } from './uploadSlice';
+import { styled } from '@stitches/react';
 
 const bulkUploadSchema = Yup.object().shape({
   images_zip: Yup.mixed().required('File is required'),
+});
+
+const Table = styled('table', {
+  borderSpacing: '0',
+})
+
+const TableHead = styled('th', {
+  textAlign: 'left',
+  verticalAlign: 'bottom',
+  padding: '5px 15px',
+});
+
+const TableRow = styled('tr', {
+  '&:nth-child(odd)': {
+    backgroundColor: '$backgroundDark',
+  },
+});
+
+const TableCell = styled('td', {
+  padding: '5px 15px',
+  verticalAlign: 'top',
 });
 
 const BulkUploadForm = ({ handleClose }) => {
@@ -30,14 +52,14 @@ const BulkUploadForm = ({ handleClose }) => {
 
   return (
     <div>
-      <table>
+      <Table>
         <thead>
           <tr>
-            <th>ID</th>
-            <th>Process start</th>
-            <th>Process end</th>
-            <th>Total images</th>
-            <th>Remaining images</th>
+            <TableHead>ID</TableHead>
+            <TableHead>Process start</TableHead>
+            <TableHead>Process end</TableHead>
+            <TableHead>Total images</TableHead>
+            <TableHead>Remaining images</TableHead>
           </tr>
         </thead>
         <tbody>
@@ -45,17 +67,18 @@ const BulkUploadForm = ({ handleClose }) => {
             const start = new Date(parseInt(processingStart)).toLocaleString();
             const end = processingEnd && new Date(parseInt(processingEnd)).toLocaleString();
             return (
-              <tr key={_id}>
-                <td>{eTag}</td>
-                <td>{start}</td>
-                <td>{end}</td>
-                <td>{total}</td>
-                <td>{remaining}</td>
-              </tr>
+              <TableRow key={_id}>
+                <TableCell>{eTag}</TableCell>
+                <TableCell>{start}</TableCell>
+                <TableCell>{end}</TableCell>
+                <TableCell>{total}</TableCell>
+                <TableCell>{remaining}</TableCell>
+              </TableRow>
             )}
           )}
         </tbody>
-      </table>
+      </Table>
+
       <FormWrapper>
         <Formik
           onSubmit={(values) => handleSubmit(values)}

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -3,10 +3,14 @@ import { Auth } from 'aws-amplify';
 import { call } from '../../api';
 
 const initialState = {
-  isLoading: false,
-  operation: null,
-  errors: null,
-  progress: 0
+  loadingStates: {
+    upload: {
+      isLoading: false,
+      operation: null,
+      errors: null,
+      progress: 0,
+    }
+  }
 };
 
 export const uploadSlice = createSlice({
@@ -14,25 +18,49 @@ export const uploadSlice = createSlice({
   initialState,
   reducers: {
     uploadStart: (state) => {
-      state.isLoading = true;
-      state.operation = 'uploading';
-      state.errors = null;
-      state.progress = 0;
+      const ls = {
+        isLoading: true,
+        operation: 'uploading',
+        errors: null,
+        progress: 0,
+      }
+      state.loadingStates.projects = {
+        ...state.loadingStates.projects,
+        ...ls
+      };
     },
 
     uploadFailure: (state, { payload }) => {
-      state.isLoading = false;
-      state.operation = null;
-      state.errors = payload;
+      const ls = {
+        isLoading: false,
+        operation: null,
+        errors: payload,
+      }
+      state.loadingStates.projects = {
+        ...state.loadingStates.projects,
+        ...ls
+      };
     },
 
-    uploadSuccess: (state, { payload }) => {
-      state.isLoading = false;
-      state.operation = null;
+    uploadSuccess: (state) => {
+      const ls = {
+        isLoading: false,
+        operation: null,
+      }
+      state.loadingStates.projects = {
+        ...state.loadingStates.projects,
+        ...ls
+      };
     },
 
     uploadProgress: (state, { payload }) => {
-      state.progress = payload.progress;
+      const ls = {
+        progress: payload.progress
+      }
+      state.loadingStates.projects = {
+        ...state.loadingStates.projects,
+        ...ls
+      };
     },
   }
 });

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -129,14 +129,17 @@ export const uploadFile = (payload) => async (dispatch, getState) => {
     if (token) {
       dispatch(uploadStart());
 
+      const { file } = payload;
       const projects = getState().projects.projects;
       const selectedProj = projects.find((proj) => proj.selected);
       const uploadUrl = await call({
         request: 'getSignedUrl',
-        projId: selectedProj._id
+        projId: selectedProj._id,
+        input: {
+          originalFile: file.name
+        }
       });
       const signedUrl = uploadUrl.createUpload.url;
-      const { file } = payload;
 
       const xhr = new XMLHttpRequest();
       await new Promise((resolve) => {

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -24,8 +24,8 @@ export const uploadSlice = createSlice({
         errors: null,
         progress: 0,
       }
-      state.loadingStates.projects = {
-        ...state.loadingStates.projects,
+      state.loadingStates.upload = {
+        ...state.loadingStates.upload,
         ...ls
       };
     },
@@ -36,8 +36,8 @@ export const uploadSlice = createSlice({
         operation: null,
         errors: payload,
       }
-      state.loadingStates.projects = {
-        ...state.loadingStates.projects,
+      state.loadingStates.upload = {
+        ...state.loadingStates.upload,
         ...ls
       };
     },
@@ -47,8 +47,8 @@ export const uploadSlice = createSlice({
         isLoading: false,
         operation: null,
       }
-      state.loadingStates.projects = {
-        ...state.loadingStates.projects,
+      state.loadingStates.upload = {
+        ...state.loadingStates.upload,
         ...ls
       };
     },
@@ -57,8 +57,8 @@ export const uploadSlice = createSlice({
       const ls = {
         progress: payload.progress
       }
-      state.loadingStates.projects = {
-        ...state.loadingStates.projects,
+      state.loadingStates.upload = {
+        ...state.loadingStates.upload,
         ...ls
       };
     },

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -57,7 +57,7 @@ const mergeBatchData = (oldBatchData, newBatchData) => {
 
     return {
       ...existingBatch,
-      ...batchUpdate.batch
+      ...batchUpdate
     }
   });
 }
@@ -284,9 +284,11 @@ export const fetchBatches = (page = 'current') => async (dispatch, getState) => 
         input: { user: userAud, pageInfo, page }
       })
 
-      const ongoingBatches = batches.batches.batches.filter(
-        ({ processingEnd, remaining }) => !processingEnd && !remaining
-      );
+      // const ongoingBatches = batches.batches.batches.filter(
+      //   ({ processingEnd, remaining }) => !processingEnd && !remaining
+      // );
+
+      const ongoingBatches = batches.batches.batches;
 
       const requests = ongoingBatches.map(({ _id: id }) => call({
         request: 'getBatch',

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -1,0 +1,80 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+const initialState = {
+  isLoading: false,
+  operation: null,
+  errors: null,
+  progress: 0
+};
+
+export const uploadSlice = createSlice({
+  name: 'uploads',
+  initialState,
+  reducers: {
+    uploadStart: (state) => {
+      state.isLoading = true;
+      state.operation = 'uploading';
+      state.errors = null;
+      state.progress = 0;
+    },
+
+    uploadFailure: (state, { payload }) => {
+      state.isLoading = false;
+      state.operation = null;
+      state.errors = payload;
+    },
+
+    uploadSuccess: (state, { payload }) => {
+      state.isLoading = false;
+      state.operation = null;
+    },
+
+    uploadProgress: (state, { payload }) => {
+      state.progress = payload.progress;
+    },
+  }
+});
+
+export const {
+  uploadStart,
+  uploadSuccess,
+  uploadFailure,
+  uploadProgress,
+} = uploadSlice.actions;
+
+// bulk upload thunk
+export const uploadFile = (payload) => async dispatch => {
+  try {
+    dispatch(uploadStart());
+    // TODO: get signed URL
+    const signedUrl = 'https://ae03e36e-3454-4e5e-a4e8-1afe525c0019.mock.pstmn.io/file-upload'; 
+
+    var data = new FormData()
+    data.append('images_zip', payload.images_zip)
+
+    const xhr = new XMLHttpRequest();
+    await new Promise((resolve) => {
+      xhr.upload.addEventListener("progress", (event) => {
+        if (event.lengthComputable) {
+          dispatch(uploadProgress({ progress: event.loaded / event.total }))
+        }
+      });
+      xhr.addEventListener("loadend", () => {
+        resolve(xhr.readyState === 4 && xhr.status === 200);
+      });
+      // TODO: use signed URL
+      xhr.open('POST', signedUrl, true);
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
+      xhr.send(data);
+    })
+
+    dispatch(uploadSuccess());
+  } catch (err) {
+    console.log('err: ', err)
+    dispatch(uploadFailure(err))
+  }
+}
+
+export const selectUploadsLoading = state => state.uploads;
+
+export default uploadSlice.reducer;

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -29,6 +29,20 @@ const initialState = {
   }
 };
 
+const equalBatches = (batch1, batch2) => {
+  // Returns true if two arrays of batches contain the same batches.
+  // NOTE: This doesn't mean the objects in each array are equal.
+  //
+  // We use this do work out if we need to update the objects currently in
+  // state (if true) or if we need to overwrite the state (if false). 
+
+  if (batch1.length !== batch2.length) return false;
+
+  const batch1Ids = batch1.map(({ _id }) => _id).sort();
+  const batch2Ids = batch2.map(({ _id }) => _id).sort();
+  return JSON.stringify(batch1Ids) === JSON.stringify(batch2Ids);
+}
+
 const mergeBatchData = (oldBatchData, newBatchData) => {
   // Merges two arrays of batches, used to update batch data with the `remaining` value
   if (oldBatchData.length === 0) {
@@ -125,7 +139,7 @@ export const uploadSlice = createSlice({
         ...ls
       };
 
-      if (payload.overwrite) {
+      if (!equalBatches(state.batchStates, batches)) {
         state.batchStates = batches;
       } else {
         // removes all fields where value === null from the object,
@@ -282,7 +296,7 @@ export const fetchBatches = (page = 'current') => async (dispatch, getState) => 
       Promise.all(requests)
         .then(batches => dispatch(fetchBatchDetailSuccess({ batches })));
 
-      dispatch(fetchBatchesSuccess({ batches, overwrite: page !== 'current' }));
+      dispatch(fetchBatchesSuccess({ batches }));
     }
   } catch (err) {
     console.log('err: ', err)

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -174,9 +174,11 @@ export const fetchBatches = () => async (dispatch, getState) => {
     if (token) {
       const projects = getState().projects.projects;
       const selectedProj = projects.find((proj) => proj.selected);
+      const userAud = getState().user.aud;
       const batches = await call({
         request: 'getBatches',
-        projId: selectedProj._id
+        projId: selectedProj._id,
+        input: { user: userAud }
       })
       dispatch(fetchBatchesSuccess({ batches }));
     }

--- a/src/features/user/userSlice.js
+++ b/src/features/user/userSlice.js
@@ -6,6 +6,7 @@ const initialState = {
   groups: [],
   projects: {},
   authStatus: null,
+  aud: null,
 };
 
 export const userSlice = createSlice({
@@ -17,6 +18,7 @@ export const userSlice = createSlice({
       state.authStatus = payload.authStatus;
       state.username = payload.username || null;
       state.groups = payload.groups || null;
+      state.aud = payload.aud || null;
       if (payload.groups) {
         state.projects = payload.groups.reduce((projects, group) => {
           const groupComponents = group.split('/');


### PR DESCRIPTION
Adds initial UI components to enable uploading ZIP archives for bulk processing. 

Major changes:

- Added a new button and modal for the upload, including a form
- Implemented the upload (against a fake postman API for now, while Nick is working on the backend implementation)
- Added upload progress tracking and a progress bar. It used XMLHttpRequest because fetch doesn't allow for tracking progress. I'm also aware that we might have to make some changes to the implementation once the upload API is in place. 

Opening this as a draft PR for to get some initial feedback, @nathanielrindlaub. Specifically looking for notes on reducers and thunks. I placed them in the project slice, but I'm not sure this is the right place. Should this go into a separate slice? 