### PR TITLE
Support updating of multiple labels/objects at once

### DIFF
--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -391,9 +391,7 @@ const queries = {
     template: `
       mutation UpdateObjects($input: UpdateObjectsInput!) {
         updateObjects(input: $input) {
-          images {
-            ${imageFields}
-          }
+          isOk
         }
       }
     `,
@@ -430,9 +428,7 @@ const queries = {
     template: `
       mutation UpdateLabels($input: UpdateLabelsInput!) {
         updateLabels(input: $input) {
-          images {
-            ${imageFields}
-          }
+          isOk
         }
       }
     `,

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -439,11 +439,11 @@ const queries = {
     variables: { input: input },
   }),
 
-  updateLabel: (input) => ({
+  updateLabels: (input) => ({
     template: `
-      mutation UpdateLabel($input: UpdateLabelInput!) {
-        updateLabel(input: $input) {
-          image {
+      mutation UpdateLabels($input: UpdateLabelsInput!) {
+        updateLabels(input: $input) {
+          images {
             ${imageFields}
           }
         }

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -396,26 +396,22 @@ const queries = {
     variables: { input: input },
   }),
 
-  deleteObject: (input) => ({
+  deleteObjects: (input) => ({
     template: `
-      mutation DeleteObject($input: DeleteObjectInput!) {
-        deleteObject(input: $input) {
-          image {
-            ${imageFields}
-          }
+      mutation DeleteObjects($input: DeleteObjectsInput!) {
+        deleteObjects(input: $input) {
+          isOk
         }
       }
     `,
     variables: { input: input },
   }),
 
-  createLabel: (input) => ({
+  createLabels: (input) => ({
     template: `
       mutation CreateLabels($input: CreateLabelsInput!) {
         createLabels(input: $input) {
-          image {
-            ${imageFields}
-          }
+          isOk
         }
       }
     `,
@@ -433,13 +429,11 @@ const queries = {
     variables: { input: input },
   }),
 
-  deleteLabel: (input) => ({
+  deleteLabels: (input) => ({
     template: `
-      mutation DeleteLabel($input: DeleteLabelInput!) {
-        deleteLabel(input: $input) {
-          image {
-            ${imageFields}
-          }
+      mutation DeleteLabels($input: DeleteLabelsInput!) {
+        deleteLabels(input: $input) {
+          isOk
         }
       }
     `,

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -374,13 +374,11 @@ const queries = {
     variables: { input: input },
   }),
 
-  createObject: (input) => ({
+  createObjects: (input) => ({
     template: `
-      mutation CreateObject($input: CreateObjectInput!) {
-        createObject(input: $input) {
-          image {
-            ${imageFields}
-          }
+      mutation CreateObjects($input: CreateObjectsInput!) {
+        createObjects(input: $input) {
+          isOk
         }
       }
     `,

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -374,19 +374,6 @@ const queries = {
     variables: { input: input },
   }),
 
-  // updateObjects: (input) => ({
-  //   template: `
-  //     mutation UpdateObjects($input: UpdateObjectsInput!) {
-  //       updateObjects(input: $input) {
-  //         image {
-  //           ${imageFields}
-  //         }
-  //       }
-  //     }
-  //   `,
-  //   variables: { input: input },
-  // }),
-
   createObject: (input) => ({
     template: `
       mutation CreateObject($input: CreateObjectInput!) {
@@ -400,11 +387,11 @@ const queries = {
     variables: { input: input },
   }),
 
-  updateObject: (input) => ({
+  updateObjects: (input) => ({
     template: `
-      mutation UpdateObject($input: UpdateObjectInput!) {
-        updateObject(input: $input) {
-          image {
+      mutation UpdateObjects($input: UpdateObjectsInput!) {
+        updateObjects(input: $input) {
+          images {
             ${imageFields}
           }
         }

--- a/src/features/loupe/BoundingBox.jsx
+++ b/src/features/loupe/BoundingBox.jsx
@@ -17,7 +17,7 @@ import {
 } from '../../components/ContextMenu';
 import { 
   bboxUpdated,
-  labelValidated, 
+  labelsValidated, 
   setFocus,
   objectManuallyUnlocked
 } from '../review/reviewSlice';
@@ -230,12 +230,14 @@ const BoundingBox = ({
 
   const handleValidationMenuItemClick = (e, validated) => {
     e.stopPropagation();
-    dispatch(labelValidated({
-      userId: username,
-      imgId,
-      objId: object._id,
-      lblId: label._id,
-      validated,
+    dispatch(labelsValidated({
+      labels: [{
+        userId: username,
+        imgId,
+        objId: object._id,
+        lblId: label._id,
+        validated,
+      }]
     }));
   };
 

--- a/src/features/loupe/BoundingBoxLabel.jsx
+++ b/src/features/loupe/BoundingBoxLabel.jsx
@@ -4,7 +4,7 @@ import { styled } from '../../theme/stitches.config.js';
 import CreatableSelect from 'react-select/creatable';
 import { createFilter } from 'react-select';
 import { selectAvailLabels } from '../filters/filtersSlice.js';
-import { labelAdded, setFocus } from '../review/reviewSlice.js';
+import { labelsAdded, setFocus } from '../review/reviewSlice.js';
 import { addLabelStart, addLabelEnd, selectIsAddingLabel } from './loupeSlice.js';
 import ValidationButtons from './ValidationButtons.jsx';
 
@@ -193,13 +193,15 @@ const BoundingBoxLabel = ({
   const handleCategoryChange = (newValue) => {
     if (!newValue) return;
     setTempObject(null);
-    dispatch(labelAdded({
-      objIsTemp: object.isTemp,
-      userId: username,
-      bbox: object.bbox,
-      category: newValue.value || newValue,
-      objId: object._id,
-      imgId
+    dispatch(labelsAdded({
+      labels: [{
+        objIsTemp: object.isTemp,
+        userId: username,
+        bbox: object.bbox,
+        category: newValue.value || newValue,
+        objId: object._id,
+        imgId
+      }]
     }));
   };
 

--- a/src/features/loupe/BoundingBoxLabel.jsx
+++ b/src/features/loupe/BoundingBoxLabel.jsx
@@ -192,18 +192,15 @@ const BoundingBoxLabel = ({
 
   const handleCategoryChange = (newValue) => {
     if (!newValue) return;
-    const category = newValue.value || newValue;
-    if (newValue) {
-      setTempObject(null);
-      dispatch(labelAdded({
-        objIsTemp: object.isTemp,
-        userId: username,
-        bbox: object.bbox,
-        category,
-        objId: object._id,
-        imgId,
-      }));
-    }
+    setTempObject(null);
+    dispatch(labelAdded({
+      objIsTemp: object.isTemp,
+      userId: username,
+      bbox: object.bbox,
+      category: newValue.value || newValue,
+      objId: object._id,
+      imgId
+    }));
   };
 
   return (

--- a/src/features/loupe/FullSizeImage.jsx
+++ b/src/features/loupe/FullSizeImage.jsx
@@ -139,7 +139,7 @@ const FullSizeImage = ({ image, focusIndex }) => {
       dispatch(labelsValidated({ labels: labelsToValidate }))
     }
     else {
-      dispatch(markedEmpty({ imgId: image._id, userId }));
+      dispatch(markedEmpty({ images: [{ imgId: image._id }], userId }));
     }
   };
 

--- a/src/features/loupe/FullSizeImage.jsx
+++ b/src/features/loupe/FullSizeImage.jsx
@@ -7,7 +7,7 @@ import { styled } from '../../theme/stitches.config';
 import { selectUserUsername, selectUserCurrentRoles } from '../user/userSlice';
 import { hasRole, WRITE_OBJECTS_ROLES } from '../../auth/roles';
 import { drawBboxStart, selectIsDrawingBbox} from './loupeSlice';
-import { selectWorkingImages, labelValidated, markedEmpty } from '../review/reviewSlice';
+import { selectWorkingImages, labelsValidated, markedEmpty } from '../review/reviewSlice';
 import { Image } from '../../components/Image';
 import BoundingBox from './BoundingBox';
 import DrawBboxOverlay from './DrawBboxOverlay';
@@ -122,19 +122,21 @@ const FullSizeImage = ({ image, focusIndex }) => {
 
   const handleMarkEmptyButtonClick = () => {
     if (emptyLabels.length > 0) {
+      const labelsToValidate = [];
       currImgObjects.forEach((obj) => {
         obj.labels
-          .filter((lbl) => (lbl.category === 'empty' && !lbl.validated))
+          .filter((lbl) => lbl.category === 'empty' && !lbl.validated)
           .forEach((lbl) => {
-            dispatch(labelValidated({
+            labelsToValidate.push({
               imgId: image._id,
               objId: obj._id,
               lblId: lbl._id,
               userId,
               validated: true
-            }));
+            });
         });
       });
+      dispatch(labelsValidated({ labels: labelsToValidate }))
     }
     else {
       dispatch(markedEmpty({ imgId: image._id, userId }));

--- a/src/features/loupe/LoupeFooter.jsx
+++ b/src/features/loupe/LoupeFooter.jsx
@@ -121,7 +121,7 @@ const LoupeFooter = ({ image }) => {
     //   if (e.code === 'ArrowRight' || e.code === 'Enter') validated = true;
     //   if (e.code === 'ArrowLeft') validated = false;
     //   if (typeof variable == 'boolean') {
-    //     dispatch(labelValidated({
+    //     dispatch(labelsValidated({
     //       userId: username,
     //       imageId: image._id,
     //       objId: object._id,

--- a/src/features/loupe/ValidationButtons.jsx
+++ b/src/features/loupe/ValidationButtons.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { styled } from '../../theme/stitches.config.js';
 import { Cross2Icon, CheckIcon, LockOpen1Icon } from '@radix-ui/react-icons';
-import { labelValidated, objectManuallyUnlocked } from '../review/reviewSlice.js';
+import { labelsValidated, objectManuallyUnlocked } from '../review/reviewSlice.js';
 
 const LabelButton = styled('button', {
   padding: '0',
@@ -38,12 +38,14 @@ const ValidationButtons = ({
 
   const handleValidationButtonClick = (e, validated) => {
     e.stopPropagation();
-    dispatch(labelValidated({
-      userId: username,
-      imgId,
-      objId: object._id,
-      lblId: label._id,
-      validated,
+    dispatch(labelsValidated({
+      labels: [{
+        userId: username,
+        imgId,
+        objId: object._id,
+        lblId: label._id,
+        validated,
+      }]
     }));
   };
 

--- a/src/features/review/labelMiddleware.js
+++ b/src/features/review/labelMiddleware.js
@@ -47,9 +47,11 @@ export const labelMiddleware = store => next => action => {
     next(action);
 
     if (objIsTemp) {
-      store.dispatch(editLabel('create', 'object', {
-        object: action.payload.newObject,
-        imageId: imgId,
+      store.dispatch(editLabel('create', 'objects', {
+        objects: [{
+          object: action.payload.newObject,
+          imageId: imgId,
+        }]
       }));
     }
     else {

--- a/src/features/review/labelMiddleware.js
+++ b/src/features/review/labelMiddleware.js
@@ -119,11 +119,13 @@ export const labelMiddleware = store => next => action => {
 
     // update label
     const validation = { validated, userId };
-    store.dispatch(editLabel('update', 'label', {
-      imageId: imgId,
-      objectId: objId,
-      labelId: lblId,
-      diffs: { validation },
+    store.dispatch(editLabel('update', 'labels', {
+      updates: [{
+        imageId: imgId,
+        objectId: objId,
+        labelId: lblId,
+        diffs: { validation },
+      }]
     }));
 
     // update object
@@ -143,11 +145,13 @@ export const labelMiddleware = store => next => action => {
     const { imgId, objId, lblId, oldValidation, oldLocked } = action.payload;
 
     // update label
-    store.dispatch(editLabel('update', 'label', {
-      imageId: imgId,
-      objectId: objId,
-      labelId: lblId,
-      diffs: { validation: oldValidation },
+    store.dispatch(editLabel('update', 'labels', {
+      updates: [{
+        imageId: imgId,
+        objectId: objId,
+        labelId: lblId,
+        diffs: { validation: oldValidation },
+      }]
     }));
 
     // update object

--- a/src/features/review/objectMiddleware.js
+++ b/src/features/review/objectMiddleware.js
@@ -17,10 +17,12 @@ export const objectMiddleware = store => next => action => {
   if (bboxUpdated.match(action)) {
     next(action);
     const { imgId, objId, bbox } = action.payload;
-    store.dispatch(editLabel('update', 'object', {
-      imageId: imgId,
-      objectId: objId,
-      diffs: { bbox },
+    store.dispatch(editLabel('update', 'objects', {
+      updates: [{
+        imageId: imgId,
+        objectId: objId,
+        diffs: { bbox },
+      }]
     }));
   }
 
@@ -28,7 +30,7 @@ export const objectMiddleware = store => next => action => {
 
   else if (objectRemoved.match(action)) {
     const { imgId, objId } = action.payload;
-    store.dispatch(editLabel('delete', 'object', {
+    store.dispatch(editLabel('delete', 'objects', {
       imageId: imgId,
       objectId: objId,
     }));
@@ -40,10 +42,12 @@ export const objectMiddleware = store => next => action => {
   else if (objectLocked.match(action)) {
     next(action);
     const { imgId, objId, locked } = action.payload;
-    store.dispatch(editLabel('update', 'object', {
-      imageId: imgId,
-      objectId: objId,
-      diffs: { locked },
+    store.dispatch(editLabel('update', 'objects', {
+      updates: [{
+        imageId: imgId,
+        objectId: objId,
+        diffs: { locked },
+      }]
     }));
   }
 

--- a/src/features/review/objectMiddleware.js
+++ b/src/features/review/objectMiddleware.js
@@ -4,7 +4,7 @@ import {
   editLabel,
   bboxUpdated,
   objectRemoved,
-  objectLocked,
+  objectsLocked,
   objectManuallyUnlocked,
   markedEmpty,
   markedEmptyReverted,
@@ -37,18 +37,17 @@ export const objectMiddleware = store => next => action => {
     next(action);
   }
 
-  /* objectLocked */
+  /* objectsLocked */
 
-  else if (objectLocked.match(action)) {
+  else if (objectsLocked.match(action)) {
+    console.log('objectMiddleware - objectsLoked - action: ', action);
     next(action);
-    const { imgId, objId, locked } = action.payload;
-    store.dispatch(editLabel('update', 'objects', {
-      updates: [{
-        imageId: imgId,
-        objectId: objId,
-        diffs: { locked },
-      }]
-    }));
+    const updates = action.payload.objects.map(({ imgId, objId, locked }) => ({
+      imageId: imgId,
+      objectId: objId,
+      diffs: { locked },
+    }))
+    store.dispatch(editLabel('update', 'objects', { updates }));
   }
 
   /* objectManuallyUnlocked */
@@ -56,7 +55,8 @@ export const objectMiddleware = store => next => action => {
   else if (objectManuallyUnlocked.match(action)) {
     next(action);
     const { imgId, objId } = action.payload;
-    store.dispatch(objectLocked({ imgId, objId, locked: false }));
+    const objects = [{ imgId, objId, locked: false }];
+    store.dispatch(objectsLocked({ objects }));
   }
 
   /* markedEmpty */

--- a/src/features/review/objectMiddleware.js
+++ b/src/features/review/objectMiddleware.js
@@ -30,7 +30,7 @@ export const objectMiddleware = store => next => action => {
 
   else if (objectRemoved.match(action)) {
     const { imgId, objId } = action.payload;
-    store.dispatch(editLabel('delete', 'objects', {
+    store.dispatch(editLabel('delete', 'object', {
       imageId: imgId,
       objectId: objId,
     }));
@@ -80,9 +80,11 @@ export const objectMiddleware = store => next => action => {
     };
 
     next(action);
-    store.dispatch(editLabel('create', 'object', {
-      object: action.payload.newObject,
-      imageId: imgId,
+    store.dispatch(editLabel('create', 'objects', {
+      objects: [{
+        object: action.payload.newObject,
+        imageId: imgId,
+      }]
     }));
   }
 

--- a/src/features/review/reviewSlice.js
+++ b/src/features/review/reviewSlice.js
@@ -181,8 +181,6 @@ export const editLabel = (operation, entity, payload, projId) => {
       const selectedProj = projects.find((proj) => proj.selected);
 
       if (token && selectedProj) {
-        // TODO: do we really need to pass in the operation and entity separately?
-        // why not just do one string, e.g.: 'createObject'
         const req = operation + entity.charAt(0).toUpperCase() + entity.slice(1);
         const res = await call({
           projId: selectedProj._id, 

--- a/src/features/review/reviewSlice.js
+++ b/src/features/review/reviewSlice.js
@@ -74,24 +74,30 @@ export const reviewSlice = createSlice({
       }
     },
 
-    labelValidated: (state, { payload }) => {
-      const { userId, imgId, objId, lblId, validated } = payload;
-      const label = findLabel(state.workingImages, imgId, objId, lblId);
-      label.validation = { validated, userId };
+    labelsValidated: (state, { payload }) => {
+      console.log('reviewSlice - labelsValidated - payload: ', payload);
+      payload.labels.forEach(({ userId, imgId, objId, lblId, validated }) => {
+        const label = findLabel(state.workingImages, imgId, objId, lblId);
+        label.validation = { validated, userId };
+      });
     },
 
-    labelValidationReverted: (state, { payload }) => { // for undoing a validation
-      const { imgId, objId, lblId, oldValidation, oldLocked } = payload;
-      const object = findObject(state.workingImages, imgId, objId);
-      object.locked = oldLocked;
-      const label = findLabel(state.workingImages, imgId, objId, lblId);
-      label.validation = oldValidation;
+    labelsValidationReverted: (state, { payload }) => { // for undoing a validation
+      console.log('reviewSlice - labelsValidationReverted - payload: ', payload);
+      payload.labels.forEach(({ imgId, objId, lblId, oldValidation, oldLocked }) => {
+        const object = findObject(state.workingImages, imgId, objId);
+        object.locked = oldLocked;
+        const label = findLabel(state.workingImages, imgId, objId, lblId);
+        label.validation = oldValidation;
+      });
     },
 
-    objectLocked: (state, { payload }) => {
-      const { imgId, objId } = payload;
-      const object = findObject(state.workingImages, imgId, objId);
-      object.locked = payload.locked;
+    objectsLocked: (state, { payload }) => {
+      console.log('reviewSlice - objectsLocked - payload: ', payload);
+      payload.objects.forEach(({ imgId, objId, locked }) => {
+        const object = findObject(state.workingImages, imgId, objId);
+        object.locked = locked;
+      });
     },
 
     markedEmpty: (state, { payload }) => {
@@ -145,9 +151,9 @@ export const {
   objectRemoved,
   labelAdded,
   labelRemoved,
-  labelValidated,
-  labelValidationReverted,
-  objectLocked,
+  labelsValidated,
+  labelsValidationReverted,
+  objectsLocked,
   markedEmpty,
   editLabelStart,
   editLabelFailure,

--- a/src/features/review/reviewSlice.js
+++ b/src/features/review/reviewSlice.js
@@ -38,39 +38,43 @@ export const reviewSlice = createSlice({
       object.bbox = payload.bbox;
     },
 
-    objectRemoved: (state, { payload }) => {
-      const image = findImage(state.workingImages, payload.imgId);
-      const objectIndex = image.objects.findIndex((obj) => (
-        obj._id === payload.objId
-      ));
-      image.objects.splice(objectIndex, 1);
-    },
-
-    labelAdded: (state, { payload }) => {
-      const { imgId, objId, objIsTemp, newObject, newLabel } = payload;
-      const image = findImage(state.workingImages, imgId);
-      if (objIsTemp && newObject) {
-        image.objects.unshift(newObject);
-      }
-      else {
-        const object = image.objects.find((obj) => obj._id === objId);
-        object.labels.unshift(newLabel);
-      }
-    },
-
-    labelRemoved: (state, { payload }) => {
-      const { imgId, objId, newLabel } = payload;
-      const image = findImage(state.workingImages, imgId);
-      const object = image.objects.find((obj) => obj._id === objId);
-      const labelIndex = object.labels.findIndex((lbl) => (
-        lbl._id === newLabel._id
-      ));
-      object.labels.splice(labelIndex, 1);
-
-      // remove object if there aren't any labels left 
-      if (!object.labels.length) {
-        const objectIndex = image.objects.findIndex((obj) => obj._id === objId);
+    objectsRemoved: (state, { payload }) => {
+      for (const obj of payload.objects) {
+        const image = findImage(state.workingImages, obj.imgId);
+        const objectIndex = image.objects.findIndex((o) => o._id === obj.objId);
         image.objects.splice(objectIndex, 1);
+      }
+    },
+
+    labelsAdded: (state, { payload }) => {
+      for (const label of payload.labels) {
+        const { imgId, objId, objIsTemp, newObject, newLabel } = label;
+        const image = findImage(state.workingImages, imgId);
+        if (objIsTemp && newObject) {
+          image.objects.unshift(newObject);
+        }
+        else {
+          const object = image.objects.find((obj) => obj._id === objId);
+          object.labels.unshift(newLabel);
+        }
+      }
+    },
+
+    labelsRemoved: (state, { payload }) => {
+      for (const label of payload.labels) {
+        const { imgId, objId, newLabel } = label;
+        const image = findImage(state.workingImages, imgId);
+        const object = image.objects.find((obj) => obj._id === objId);
+        const labelIndex = object.labels.findIndex((lbl) => (
+          lbl._id === newLabel._id
+        ));
+        object.labels.splice(labelIndex, 1);
+  
+        // remove object if there aren't any labels left 
+        if (!object.labels.length) {
+          const objectIndex = image.objects.findIndex((obj) => obj._id === objId);
+          image.objects.splice(objectIndex, 1);
+        }
       }
     },
 
@@ -101,9 +105,11 @@ export const reviewSlice = createSlice({
     },
 
     markedEmpty: (state, { payload }) => {
-      if (payload.newObject) {
-        const image = findImage(state.workingImages, payload.imgId);
-        image.objects.push(payload.newObject);
+      for (const img of payload.images) {
+        if (img.newObject) {
+          const image = findImage(state.workingImages, img.imgId);
+          image.objects.push(img.newObject);
+        }
       }
     },
 
@@ -148,9 +154,9 @@ export const reviewSlice = createSlice({
 export const {
   setFocus,
   bboxUpdated,
-  objectRemoved,
-  labelAdded,
-  labelRemoved,
+  objectsRemoved,
+  labelsAdded,
+  labelsRemoved,
   labelsValidated,
   labelsValidationReverted,
   objectsLocked,

--- a/src/features/review/undoMiddleware.js
+++ b/src/features/review/undoMiddleware.js
@@ -1,13 +1,13 @@
 import { createUndoMiddleware } from 'redux-undo-redo';
 import {
   bboxUpdated,
-  labelAdded,
+  labelsAdded,
   objectsLocked,
   objectManuallyUnlocked,
   labelsValidated,
   labelsValidationReverted,
   selectWorkingImages,
-  labelRemoved,
+  labelsRemoved,
   markedEmpty,
   markedEmptyReverted,
 } from './reviewSlice';
@@ -16,11 +16,11 @@ import { findObject } from '../../app/utils';
 export const undoMiddleware = createUndoMiddleware({
   revertingActions: {
 
-    // labelAdded
-    [labelAdded.toString()]: {
+    // labelsAdded
+    [labelsAdded.toString()]: {
       action: (action) => {
-        console.log('reverting labelAdded with action: ', action);
-        return labelRemoved(action.payload);
+        console.log('reverting labelsAdded with action: ', action);
+        return labelsRemoved(action.payload);
       },
     },
 


### PR DESCRIPTION
A first step towards https://github.com/tnc-ca-geo/animl-frontend/issues/25 and https://github.com/tnc-ca-geo/animl-frontend/issues/41.

TODO: 

- [x] transition `updateLabel` mutation calls to `updateLabels` and pass in arrays of updates as payload
- [x] transition `updateObject` mutation calls to `updateObjects` and pass arrays of updates as payload
- [x] update upstream dispatched actions in components and middlewares that trigger `editLabel` (e.g. `labelValidated`, `objectLocked`) to support arrays as payloads; update reducers to handle arrays and update image state accordingly
- [x] update undo/redo handling
- [x] transition `createObject` and `deleteObject` to `createObjects` and `deleteObjects` (and update animl-api accordingly)
- [x] transition `createLabel` and `deleteLabel` to `createLabels` and `deleteLabels` (and update animl-api accordingly)
- [x] update `markedEmpty` and `markedEmptyReverted` actions to support marking multiple images as empty at once
- [x] update `objectRemoved`, `labelAdded`, `labelRemoved` actions to support multiple objects/labels