### PR TITLE
Add comments on enter (and new line on shift + enter)

### DIFF
--- a/src/features/loupe/Comment.jsx
+++ b/src/features/loupe/Comment.jsx
@@ -147,7 +147,7 @@ const timeAgoPrettyPrint = (isoDateTimeString) => {
   return 'a few seconds ago';
 };
 
-export const Comment = ({ comment, imageId, onChangeOpen }) => {
+export const Comment = ({ comment, imageId, onChangeOpen, scrollRef }) => {
   const dispatch = useDispatch();
   const authorInitial = comment.author[0].toUpperCase();
   const currentUser = useSelector(selectUserUsername);
@@ -181,7 +181,7 @@ export const Comment = ({ comment, imageId, onChangeOpen }) => {
         onDeleteConfirm={onDeleteConfirm}
         onDeleteCancel={() => setIsDeleteConfirm(false)}
       />
-      <StyledFieldRow>
+      <StyledFieldRow ref={scrollRef}>
         <StyledNameRow>
           <StyledAvatar>{authorInitial}</StyledAvatar>
           <StyledNameField>

--- a/src/features/loupe/CommentsPopover.jsx
+++ b/src/features/loupe/CommentsPopover.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import { styled } from '../../theme/stitches.config.js';
 import { PopoverClose } from '@radix-ui/react-popover';
@@ -109,6 +109,31 @@ export const CommentsPopover = ({ onClose, comments, imageId, onChangeActionMenu
     dispatch(editComment('create', addCommentDto));
     setAddCommentText('');
   };
+  // Add comment using enter
+  // Shift + Enter makes a new line
+  const [isShiftDown, setIsShiftDown] = useState(false);
+  const handleKeyDown = (event) => {
+    event.stopPropagation();
+    if (event.key === "Shift") {
+      setIsShiftDown(true);
+    }
+    if (event.key === "Enter" && !isShiftDown) {
+      handleAddComment(addCommentText);
+      event.preventDefault();
+    }
+  }
+  const handleKeyUp = (event) => {
+    if (event.key === "Shift") {
+      setIsShiftDown(false);
+    }
+  }
+  // Scroll to bottom when adding a new comment
+  const scrollRef = useRef();
+  useEffect(() => {
+    if (scrollRef.current !== undefined) {
+      scrollRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [comments]);
 
   return (
     <>
@@ -126,12 +151,13 @@ export const CommentsPopover = ({ onClose, comments, imageId, onChangeActionMenu
         </StyledHeader>
         {comments?.length > 0 && (
           <StyledCommentsContainer>
-            {comments.map((comment) => (
+            {comments.map((comment, idx) => (
               <Comment
                 key={comment._id}
                 comment={comment}
                 imageId={imageId}
                 onChangeOpen={onChangeActionMenu}
+                scrollRef={idx === comments.length - 1 ? scrollRef : undefined}
               />
             ))}
           </StyledCommentsContainer>
@@ -141,8 +167,8 @@ export const CommentsPopover = ({ onClose, comments, imageId, onChangeActionMenu
             value={addCommentText}
             onChange={(e) => setAddCommentText(e.target.value)}
             placeholder="Enter comment"
-            onKeyDown={(e) => e.stopPropagation()}
-            onKeyDownCapture={(e) => e.stopPropagation()}
+            onKeyDown={(e) => handleKeyDown(e)}
+            onKeyUp={(e) => handleKeyUp(e)}
           />
           <StyledAddCommentButton
             size="small"


### PR DESCRIPTION
**Content**

To integrate with the keyboard navigation available in the rest of the app, add new comments when using enter.  Additionally, allow for adding new lines by holding down shift and pressing enter.

QOL Fix: scroll to the bottom of the comments list when adding a new comment that causes the popover to become a scroll container.