### PR TITLE
289/267: fix comments popover bug and improve ux

### DIFF
--- a/src/features/loupe/Comment.jsx
+++ b/src/features/loupe/Comment.jsx
@@ -167,6 +167,12 @@ export const Comment = ({ comment, imageId, onChangeOpen, scrollRef }) => {
   };
 
   const onEditConfirm = () => {
+    // If all the comment's content is removed
+    // show the delete comment flow
+    if (editCommentText === "") {
+      setIsDeleteConfirm(true);
+      return;
+    }
     const editCommentDto = {
       id: comment._id,
       imageId: imageId,
@@ -174,6 +180,25 @@ export const Comment = ({ comment, imageId, onChangeOpen, scrollRef }) => {
     };
     dispatch(editComment('update', editCommentDto));
     setIsEdit(false);
+  };
+
+  // Confirm edit comment using enter
+  // Shift + Enter makes a new line
+  const [isShiftDown, setIsShiftDown] = useState(false);
+  const handleKeyDown = (event) => {
+    event.stopPropagation();
+    if (event.key === 'Shift') {
+      setIsShiftDown(true);
+    }
+    if (event.key === 'Enter' && !isShiftDown) {
+      onEditConfirm();
+      event.preventDefault();
+    }
+  };
+  const handleKeyUp = (event) => {
+    if (event.key === 'Shift') {
+      setIsShiftDown(false);
+    }
   };
 
   return (
@@ -220,8 +245,8 @@ export const Comment = ({ comment, imageId, onChangeOpen, scrollRef }) => {
             <StyledTextArea
               value={editCommentText}
               onChange={(e) => setEditCommentText(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              onKeyDownCapture={(e) => e.stopPropagation()}
+              onKeyDown={(e) => handleKeyDown(e)}
+              onKeyUp={(e) => handleKeyUp(e)}
             />
             <StyledButtonContainer>
               <Button size="small" onClick={() => setIsEdit(false)}>

--- a/src/features/loupe/CommentsPopover.jsx
+++ b/src/features/loupe/CommentsPopover.jsx
@@ -109,6 +109,7 @@ export const CommentsPopover = ({ onClose, comments, imageId, onChangeActionMenu
     dispatch(editComment('create', addCommentDto));
     setAddCommentText('');
   };
+
   // Add comment using enter
   // Shift + Enter makes a new line
   const [isShiftDown, setIsShiftDown] = useState(false);

--- a/src/features/loupe/ImageReviewToolbar.jsx
+++ b/src/features/loupe/ImageReviewToolbar.jsx
@@ -189,6 +189,11 @@ const ImageReviewToolbar = ({
     }
   };
 
+  // Close popover when changing images using keyboard
+  useEffect(() => {
+    setIsCommentsPopoverOpen(false);
+  }, [image._id]);
+
   return (
     <Toolbar>
       {hasRole(userRoles, WRITE_OBJECTS_ROLES) && (


### PR DESCRIPTION
**Context**

Fixes: https://github.com/tnc-ca-geo/animl-api/issues/289, https://github.com/tnc-ca-geo/animl-frontend/issues/261
Adds: https://github.com/tnc-ca-geo/animl-frontend/issues/267

Fixes a bug which caused errors when editing comments to include no content.  Instead, show the delete comment ui/ux similar to Slack.

Fixes bug which caused comments popover to stay open when changing images with keyboard.

Adds the 'confirm edit on enter' functionality that the new comments ui/ux has.  New lines can be added with shift + enter.

**Commits**

- feat: confirm comment edits using enter.
- fix: when removing all content from comment, show delete comment ux