### PR TITLE
Async Project Label deletion

### DIFF
--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -625,6 +625,10 @@ const queries = {
       mutation DeleteProjectLabel($input: DeleteProjectLabelInput!) {
         deleteProjectLabel(input: $input) {
           isOk
+          movingToTask
+          task {
+            _id
+          }
         }
       }
     `,

--- a/src/components/ErrorToast.jsx
+++ b/src/components/ErrorToast.jsx
@@ -50,6 +50,8 @@ import {
   dismissDeleteCameraError,
   selectDeleteImagesErrors,
   dismissDeleteImagesError,
+  selectDeleteProjectLabelErrors,
+  dismissDeleteProjectLabelTaskError,
 } from '../features/tasks/tasksSlice';
 import {
   selectRedriveBatchErrors,
@@ -86,6 +88,7 @@ const ErrorToast = () => {
   const deleteCameraErrors = useSelector(selectDeleteCameraErrors);
   const projectTagErrors = useSelector(selectProjectTagErrors);
   const deleteImagesErrors = useSelector(selectDeleteImagesErrors);
+  const deleteProjectLabelErrors = useSelector(selectDeleteProjectLabelErrors);
 
   const enrichedErrors = [
     enrichErrors(labelsErrors, 'Label Error', 'labels'),
@@ -114,6 +117,7 @@ const ErrorToast = () => {
     ),
     enrichErrors(deleteCameraErrors, 'Error Deleting Camera', 'deleteCamera'),
     enrichErrors(deleteImagesErrors, 'Error Deleting Images', 'deleteImages'),
+    enrichErrors(deleteProjectLabelErrors, 'Error Deleting Label', 'deleteProjectLabel'),
   ];
 
   const errors = enrichedErrors.reduce(
@@ -180,7 +184,8 @@ const dismissErrorActions = {
   upload: (i) => dismissUploadError(i),
   cameraSerialNumber: (i) => dismissCameraSerialNumberError(i),
   deleteCamera: (i) => dismissDeleteCameraError(i),
-  deleteImagesError: (i) => dismissDeleteImagesError(i),
+  deleteImages: (i) => dismissDeleteImagesError(i),
+  deleteProjectLabel: (i) => dismissDeleteProjectLabelTaskError(i),
 };
 
 function enrichErrors(errors, title, entity) {

--- a/src/features/projects/projectsSlice.js
+++ b/src/features/projects/projectsSlice.js
@@ -324,7 +324,6 @@ export const projectsSlice = createSlice({
     },
 
     updateProjectLabelFailure: (state, { payload }) => {
-      console.log('updateProjectLabelFailure resolver - payload: ', payload);
       const ls = { isLoading: false, operation: null, errors: payload };
       state.loadingStates.projectLabels = ls;
     },
@@ -449,10 +448,6 @@ export const projectsSlice = createSlice({
         }
       })
       .addCase(editDeploymentsSuccess, (state, { payload }) => {
-        console.log(
-          'editDeploymentsSuccess caught in projectsSlice extra reducer - payload: ',
-          payload,
-        );
         const editedCamConfig = payload.cameraConfig;
         const proj = state.projects.find((p) => p._id === payload.projId);
         for (const camConfig of proj.cameraConfigs) {
@@ -847,7 +842,9 @@ export const deleteProjectLabel = (payload) => {
           input: { ...payload, processAsTask: false },
         });
         if (res.deleteProjectLabel.movingToTask) {
-          // TODO: moving to task slice
+          // the synchronous label deletion limit has been reached,
+          // and an async task was created to complete the deletion.
+          // shifting status tracking to task slice
           dispatch(
             deleteProjectLabelTaskStart({
               projId,

--- a/src/features/tasks/tasksSlice.js
+++ b/src/features/tasks/tasksSlice.js
@@ -356,11 +356,10 @@ export const tasksSlice = createSlice({
     // delete project label
 
     deleteProjectLabelTaskStart: (state, { payload }) => {
-      console.log('deleteProjectLabelTaskStart payload: ', payload);
-      // Note: we don't need a deleteProjectLabelTaskUpdate action
+      // Note: we don't need a deleteProjectLabelTaskUpdate action in this case
       // because we already know the taskId when we start the task
       let ls = state.loadingStates.deleteProjectLabel;
-      ls.taskId = payload.taskId; // update with taskId
+      ls.taskId = payload.taskId;
       ls.isLoading = true;
       ls.errors = null;
     },
@@ -459,8 +458,6 @@ export const fetchTask = (taskId) => {
           request: 'getTask',
           input: { taskId },
         });
-
-        console.log('fetchTask - res: ', res);
 
         if (res.task.status === 'SUBMITTED' || res.task.status === 'RUNNING') {
           await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -592,7 +589,6 @@ export const fetchStats = (filters) => {
           request: 'getStats',
           input: { filters },
         });
-        console.log('tasksSlice - fetchStats() - res: ', res);
         dispatch(statsUpdate({ taskId: res.stats._id }));
       }
     } catch (err) {
@@ -617,7 +613,6 @@ export const exportAnnotations = ({ format, filters }) => {
           request: 'exportAnnotations',
           input: { format, filters },
         });
-        console.log('exportAnnotations - res: ', res);
         dispatch(exportAnnotationsUpdate({ taskId: res.exportAnnotations._id }));
       }
     } catch (err) {
@@ -672,7 +667,6 @@ export const editDeployments = (operation, payload) => {
           request: operation,
           input: payload,
         });
-        console.log('editDeployments - res: ', res);
         dispatch(editDeploymentsUpdate({ taskId: res[operation]._id }));
       }
     } catch (err) {
@@ -698,7 +692,6 @@ export const updateCameraSerialNumber = (payload) => {
           request: 'updateCameraSerialNumber',
           input: payload,
         });
-        console.log('updateCameraSerialNumber - res: ', res);
         dispatch(updateCameraSerialNumberUpdate({ taskId: res.updateCameraSerialNumber._id }));
       }
     } catch (err) {
@@ -721,7 +714,6 @@ export const deleteCamera = (payload) => {
           request: 'deleteCameraConfig',
           input: payload,
         });
-        console.log('deleteCamera - res: ', res);
         dispatch(updateDeleteCameraUpdate({ taskId: res.deleteCameraConfig._id }));
       }
     } catch (err) {


### PR DESCRIPTION
**Context**

When deleting a Project Label, if the Project has more than 25k instances of that Label applied to images, move the processing to the async Task lambda to avoid timeouts. 

Related animl-api PR: https://github.com/tnc-ca-geo/animl-api/pull/310