### PR TITLE
288: fix zooming on mobile login page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#ffffff">
     <link rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto:wght@300;400;500;600;700&display=swap">
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="Camera trap data managment"

--- a/src/features/auth/LoginForm.jsx
+++ b/src/features/auth/LoginForm.jsx
@@ -46,6 +46,10 @@ const StyledAuthenticator = styled(Authenticator, {
     width: '100%',
   },
 
+  '&[data-amplify-authenticator] [data-amplify-form]': {
+    padding: '$4',
+  },
+
   '&[data-amplify-authenticator] [data-amplify-container]': {
     width: '100%',
   },
@@ -122,7 +126,7 @@ const StyledAuthenticator = styled(Authenticator, {
   '.amplify-input': {
     display: 'inherit',
     width: '100%',
-    fontSize: '$3',
+    fontSize: '16px',
     fontFamily: '$sourceSansPro',
     color: '$textMedium',
     padding: '$3',

--- a/src/features/auth/LoginForm.jsx
+++ b/src/features/auth/LoginForm.jsx
@@ -46,10 +46,6 @@ const StyledAuthenticator = styled(Authenticator, {
     width: '100%',
   },
 
-  '&[data-amplify-authenticator] [data-amplify-form]': {
-    padding: '$4',
-  },
-
   '&[data-amplify-authenticator] [data-amplify-container]': {
     width: '100%',
   },

--- a/src/features/auth/LoginForm.jsx
+++ b/src/features/auth/LoginForm.jsx
@@ -126,7 +126,6 @@ const StyledAuthenticator = styled(Authenticator, {
   '.amplify-input': {
     display: 'inherit',
     width: '100%',
-    fontSize: '16px',
     fontFamily: '$sourceSansPro',
     color: '$textMedium',
     padding: '$3',


### PR DESCRIPTION
**Context**
Fixes #288 

- Bump the font size to 16 to avoid Safari auto zooming.
- Fix padding so that the input boxes are the same width as everything else on the screen.

Bumped the font size instead of setting `maximum-width=1` because the max width property disables pinch to zoom which is likely an important feature for people who want to review images.

Thread about issue:
https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone

Scout fix:
https://github.com/tnc-ca-geo/paikea-aws-frontend/commit/1b3a68b7e2bf9deb6f441ef1763798b4d8b55387


**Commits**
- fix(288): bump font size to avoid 'auto zoom' on safari login page