### PR TITLE
Refactor global beakpoints and add utility methods

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -17,9 +17,8 @@ import { selectRouterLocation } from '../features/images/imagesSlice';
 import { userAuthStateChanged } from '../features/auth/authSlice';
 import { mouseEventDetected, selectIsDrawingBbox } from '../features/loupe/loupeSlice';
 import logo from '../assets/animl-logo.svg';
-import { IN_MAINTENANCE_MODE, GA_CONFIG, AWS_AUTH_CONFIG } from '../config';
+import { IN_MAINTENANCE_MODE, GA_CONFIG, AWS_AUTH_CONFIG, globalBreakpoints } from '../config';
 import { setGlobalBreakpoint } from '../features/projects/projectsSlice.js';
-import { tableBreakpoints } from '../features/images/config.js';
 import useBreakpoints from '../hooks/useBreakpoints.js';
 
 Amplify.configure(AWS_AUTH_CONFIG);
@@ -138,7 +137,7 @@ const App = () => {
     if (isDrawingBbox) dispatch(mouseEventDetected({ event: 'mouse-down' }));
   };
 
-  const { ref, breakpoint } = useBreakpoints(tableBreakpoints);
+  const { ref, breakpoint } = useBreakpoints(globalBreakpoints.values);
   useEffect(() => {
     dispatch(setGlobalBreakpoint(breakpoint));
   }, [breakpoint]);

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -170,3 +170,27 @@ export const isImageReviewed = (image) => {
   );
   return hasObjs && !hasUnlockedObjs && !hasAllInvalidatedLabels;
 };
+
+// Factory to create breakpoints and utility methods
+export const createBreakpoints = (breakpointValues) => {
+  const compareBreakpoints = (bp1, bp2) => {
+    const find = (bpLabel) => breakpointValues.find((bp) => bp[0] === bpLabel);
+    const foundBp1 = find(bp1);
+    const foundBp2 = find(bp2);
+
+    if (foundBp1 === undefined || foundBp2 === undefined) {
+      const validValues = breakpointValues.map((bp) => bp[0]);
+      throw new Error(
+        `${bp1} or ${bp2} is not a valid global breakpoint label.  Valid breakpoint labels are: ${validValues.join(', ')}.`,
+      );
+    }
+
+    return foundBp1[1] - foundBp2[1];
+  };
+
+  return {
+    values: breakpointValues,
+    lessThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) <= 0,
+    greaterThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) >= 0,
+  };
+};

--- a/src/config.js
+++ b/src/config.js
@@ -46,3 +46,32 @@ export const AWS_AUTH_CONFIG = {
   aws_user_pools_web_client_id: '40mcp5odj5aek6r91g6quos3er',
   aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
 };
+
+const globalBreakpointValues = [
+  ['xxs', 540],
+  ['xs', 640],
+  ['sm', 740],
+  ['md', 840],
+  ['lg', 940],
+  ['xl', Infinity],
+];
+
+const compareBreakpoints = (bp1, bp2) => {
+  const find = (bpLabel) => globalBreakpointValues.find((bp) => bp[0] === bpLabel);
+  const foundBp1 = find(bp1);
+  const foundBp2 = find(bp2);
+
+  if (foundBp1 === undefined || foundBp2 === undefined) {
+    throw new Error(
+      `${bp1} or ${bp2} is not a valid global breakpoint label.  Valid breakpoint labels are: xxs, xs, sm, md, lg, xl.`,
+    );
+  }
+
+  return foundBp1[1] - foundBp2[1];
+};
+
+export const globalBreakpoints = {
+  values: globalBreakpointValues,
+  lessThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) <= 0,
+  greaterThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) >= 0,
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import { createBreakpoints } from './app/utils';
+
 const API_URLS = {
   // development: 'http://localhost:3000/dev/external', // if serving animl-api locally
   development: 'https://ko0yratczi.execute-api.us-west-2.amazonaws.com/dev/external', // if using dev animl-api stack on AWS
@@ -56,22 +58,4 @@ const globalBreakpointValues = [
   ['xl', Infinity],
 ];
 
-const compareBreakpoints = (bp1, bp2) => {
-  const find = (bpLabel) => globalBreakpointValues.find((bp) => bp[0] === bpLabel);
-  const foundBp1 = find(bp1);
-  const foundBp2 = find(bp2);
-
-  if (foundBp1 === undefined || foundBp2 === undefined) {
-    throw new Error(
-      `${bp1} or ${bp2} is not a valid global breakpoint label.  Valid breakpoint labels are: xxs, xs, sm, md, lg, xl.`,
-    );
-  }
-
-  return foundBp1[1] - foundBp2[1];
-};
-
-export const globalBreakpoints = {
-  values: globalBreakpointValues,
-  lessThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) <= 0,
-  greaterThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) >= 0,
-};
+export const globalBreakpoints = createBreakpoints(globalBreakpointValues);

--- a/src/config.js
+++ b/src/config.js
@@ -51,10 +51,10 @@ export const AWS_AUTH_CONFIG = {
 
 const globalBreakpointValues = [
   ['xxs', 540],
-  ['xs', 640],
-  ['sm', 740],
-  ['md', 840],
-  ['lg', 940],
+  ['xs', 768],
+  ['sm', 1024],
+  ['md', 1280],
+  ['lg', 1536],
   ['xl', Infinity],
 ];
 

--- a/src/features/filters/CameraFilterSection.jsx
+++ b/src/features/filters/CameraFilterSection.jsx
@@ -10,6 +10,7 @@ import { CheckboxWrapper } from '../../components/CheckboxWrapper.jsx';
 import { ChevronRightIcon, ChevronDownIcon } from '@radix-ui/react-icons';
 import IconButton from '../../components/IconButton.jsx';
 import { selectGlobalBreakpoint } from '../projects/projectsSlice.js';
+import { globalBreakpoints } from '../../config.js';
 
 const AdditionalDepCount = styled('div', {
   fontStyle: 'italic',
@@ -169,8 +170,8 @@ const CameraCheckboxLabel = ({ filterCat, managedIds, deployments, activeDeps })
     dispatch(checkboxOnlyButtonClicked({ filterCat, managedIds }));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const alwaysShowOnly = globalBreakpoint === 'xs' || globalBreakpoint === 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const alwaysShowOnly = globalBreakpoints.lessThanOrEqual(currentBreakpoint, 'xs');
 
   return (
     <CheckboxLabel

--- a/src/features/filters/LabelCheckboxLabel.jsx
+++ b/src/features/filters/LabelCheckboxLabel.jsx
@@ -4,6 +4,7 @@ import { styled } from '../../theme/stitches.config';
 import { CheckboxLabel } from '../../components/CheckboxLabel';
 import { checkboxOnlyButtonClicked } from './filtersSlice';
 import { selectGlobalBreakpoint } from '../projects/projectsSlice';
+import { globalBreakpoints } from '../../config';
 
 const OnlyButton = styled('div', {
   background: '$gray3',
@@ -35,8 +36,8 @@ export const LabelCheckboxLabel = ({ id, name, checked, active, filterCat }) => 
     dispatch(checkboxOnlyButtonClicked({ filterCat, managedIds: [id] }));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const alwaysShowOnly = globalBreakpoint === 'xs' || globalBreakpoint === 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const alwaysShowOnly = globalBreakpoints.lessThanOrEqual(currentBreakpoint, 'xs');
 
   return (
     <CheckboxLabel

--- a/src/features/images/ImagesPanel.jsx
+++ b/src/features/images/ImagesPanel.jsx
@@ -54,14 +54,14 @@ const ImagesPanel = () => {
       : dispatch(fetchImages(activeFilters, 'next'));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
 
   return (
     <StyledImagesPanel>
-      {globalBreakpoint !== 'xxs' && (
+      {currentBreakpoint !== 'xxs' && (
         <ImagesTable workingImages={workingImages} hasNext={hasNext} loadNextPage={loadNextPage} />
       )}
-      {globalBreakpoint === 'xxs' && (
+      {currentBreakpoint === 'xxs' && (
         <ImagesGrid workingImages={workingImages} hasNext={hasNext} loadNextPage={loadNextPage} />
       )}
     </StyledImagesPanel>

--- a/src/features/loupe/BoundingBox.jsx
+++ b/src/features/loupe/BoundingBox.jsx
@@ -26,6 +26,7 @@ import BoundingBoxLabel from './BoundingBoxLabel';
 import { absToRel, relToAbs } from '../../app/utils';
 import { CheckIcon, Cross2Icon, LockOpen1Icon, Pencil1Icon } from '@radix-ui/react-icons';
 import { selectGlobalBreakpoint, selectLabels } from '../projects/projectsSlice';
+import { globalBreakpoints } from '../../config';
 
 const ResizeHandle = styled('div', {
   width: '$3',
@@ -216,8 +217,8 @@ const BoundingBox = ({ imgId, imgDims, object, objectIndex, focusIndex, setTempO
     dispatch(bboxUpdated({ imgId, objId: object._id, bbox }));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const isSmallScreen = globalBreakpoint === 'xs' || globalBreakpoint === 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const isSmallScreen = globalBreakpoints.lessThanOrEqual(currentBreakpoint, 'xs');
 
   // manage label validation button state
   const [showLabelButtons, setShowLabelButtons] = useState(() => isSmallScreen);

--- a/src/features/projects/ViewExplorer.jsx
+++ b/src/features/projects/ViewExplorer.jsx
@@ -10,6 +10,7 @@ import Loupe from '../loupe/Loupe.jsx';
 import ErrorToast from '../../components/ErrorToast.jsx';
 import HydratedModal from '../../components/HydratedModal.jsx';
 import { selectGlobalBreakpoint } from './projectsSlice.js';
+import { globalBreakpoints } from '../../config.js';
 
 const ViewExplorerWrapper = styled('div', {
   display: 'flex',
@@ -33,17 +34,20 @@ const ViewExplorer = () => {
     setFiltersPanelOpen(!filtersPanelOpen);
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const notXsOrXxs = globalBreakpoint !== 'xs' && globalBreakpoint !== 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const isLargeScreen =
+    !currentBreakpoint || globalBreakpoints.greaterThanOrEqual(currentBreakpoint, 'sm');
 
   return (
     <ViewExplorerWrapper>
-      {notXsOrXxs && (
+      {isLargeScreen && (
         <SidebarNav toggleFiltersPanel={toggleFiltersPanel} filtersPanelOpen={filtersPanelOpen} />
       )}
-      {notXsOrXxs && filtersPanelOpen && <FiltersPanel toggleFiltersPanel={toggleFiltersPanel} />}
+      {isLargeScreen && filtersPanelOpen && (
+        <FiltersPanel toggleFiltersPanel={toggleFiltersPanel} />
+      )}
       <ImagesPanel />
-      {notXsOrXxs && loupeOpen && <Loupe />}
+      {isLargeScreen && loupeOpen && <Loupe />}
       <HydratedModal />
       <ErrorToast />
     </ViewExplorerWrapper>


### PR DESCRIPTION
**Context**

- make a new global breakpoints object so that we are not misusing the table breakpoints 
- add convenience methods to compare the current breakpoint with other sizes 

**Commits**

- feat: refactor global breakpoints, add utility methods for comparing breakpoints