### PR TITLE
304 image metadata single col

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -17,9 +17,8 @@ import { selectRouterLocation } from '../features/images/imagesSlice';
 import { userAuthStateChanged } from '../features/auth/authSlice';
 import { mouseEventDetected, selectIsDrawingBbox } from '../features/loupe/loupeSlice';
 import logo from '../assets/animl-logo.svg';
-import { IN_MAINTENANCE_MODE, GA_CONFIG, AWS_AUTH_CONFIG } from '../config';
+import { IN_MAINTENANCE_MODE, GA_CONFIG, AWS_AUTH_CONFIG, globalBreakpoints } from '../config';
 import { setGlobalBreakpoint } from '../features/projects/projectsSlice.js';
-import { tableBreakpoints } from '../features/images/config.js';
 import useBreakpoints from '../hooks/useBreakpoints.js';
 
 Amplify.configure(AWS_AUTH_CONFIG);
@@ -138,7 +137,7 @@ const App = () => {
     if (isDrawingBbox) dispatch(mouseEventDetected({ event: 'mouse-down' }));
   };
 
-  const { ref, breakpoint } = useBreakpoints(tableBreakpoints);
+  const { ref, breakpoint } = useBreakpoints(globalBreakpoints.values);
   useEffect(() => {
     dispatch(setGlobalBreakpoint(breakpoint));
   }, [breakpoint]);

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -170,3 +170,27 @@ export const isImageReviewed = (image) => {
   );
   return hasObjs && !hasUnlockedObjs && !hasAllInvalidatedLabels;
 };
+
+// Factory to create breakpoints and utility methods
+export const createBreakpoints = (breakpointValues) => {
+  const compareBreakpoints = (bp1, bp2) => {
+    const find = (bpLabel) => breakpointValues.find((bp) => bp[0] === bpLabel);
+    const foundBp1 = find(bp1);
+    const foundBp2 = find(bp2);
+
+    if (foundBp1 === undefined || foundBp2 === undefined) {
+      const validValues = breakpointValues.map((bp) => bp[0]);
+      throw new Error(
+        `${bp1} or ${bp2} is not a valid global breakpoint label.  Valid breakpoint labels are: ${validValues.join(', ')}.`,
+      );
+    }
+
+    return foundBp1[1] - foundBp2[1];
+  };
+
+  return {
+    values: breakpointValues,
+    lessThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) <= 0,
+    greaterThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) >= 0,
+  };
+};

--- a/src/config.js
+++ b/src/config.js
@@ -46,3 +46,32 @@ export const AWS_AUTH_CONFIG = {
   aws_user_pools_web_client_id: '40mcp5odj5aek6r91g6quos3er',
   aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
 };
+
+const globalBreakpointValues = [
+  ['xxs', 540],
+  ['xs', 640],
+  ['sm', 740],
+  ['md', 840],
+  ['lg', 940],
+  ['xl', Infinity],
+];
+
+const compareBreakpoints = (bp1, bp2) => {
+  const find = (bpLabel) => globalBreakpointValues.find((bp) => bp[0] === bpLabel);
+  const foundBp1 = find(bp1);
+  const foundBp2 = find(bp2);
+
+  if (foundBp1 === undefined || foundBp2 === undefined) {
+    throw new Error(
+      `${bp1} or ${bp2} is not a valid global breakpoint label.  Valid breakpoint labels are: xxs, xs, sm, md, lg, xl.`,
+    );
+  }
+
+  return foundBp1[1] - foundBp2[1];
+};
+
+export const globalBreakpoints = {
+  values: globalBreakpointValues,
+  lessThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) <= 0,
+  greaterThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) >= 0,
+};

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,5 @@
+import { createBreakpoints } from './app/utils';
+
 const API_URLS = {
   // development: 'http://localhost:3000/dev/external', // if serving animl-api locally
   development: 'https://ko0yratczi.execute-api.us-west-2.amazonaws.com/dev/external', // if using dev animl-api stack on AWS
@@ -56,22 +58,4 @@ const globalBreakpointValues = [
   ['xl', Infinity],
 ];
 
-const compareBreakpoints = (bp1, bp2) => {
-  const find = (bpLabel) => globalBreakpointValues.find((bp) => bp[0] === bpLabel);
-  const foundBp1 = find(bp1);
-  const foundBp2 = find(bp2);
-
-  if (foundBp1 === undefined || foundBp2 === undefined) {
-    throw new Error(
-      `${bp1} or ${bp2} is not a valid global breakpoint label.  Valid breakpoint labels are: xxs, xs, sm, md, lg, xl.`,
-    );
-  }
-
-  return foundBp1[1] - foundBp2[1];
-};
-
-export const globalBreakpoints = {
-  values: globalBreakpointValues,
-  lessThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) <= 0,
-  greaterThanOrEqual: (bp1, bp2) => compareBreakpoints(bp1, bp2) >= 0,
-};
+export const globalBreakpoints = createBreakpoints(globalBreakpointValues);

--- a/src/config.js
+++ b/src/config.js
@@ -51,10 +51,10 @@ export const AWS_AUTH_CONFIG = {
 
 const globalBreakpointValues = [
   ['xxs', 540],
-  ['xs', 640],
-  ['sm', 740],
-  ['md', 840],
-  ['lg', 940],
+  ['xs', 768],
+  ['sm', 1024],
+  ['md', 1280],
+  ['lg', 1536],
   ['xl', Infinity],
 ];
 

--- a/src/features/filters/CameraFilterSection.jsx
+++ b/src/features/filters/CameraFilterSection.jsx
@@ -10,6 +10,7 @@ import { CheckboxWrapper } from '../../components/CheckboxWrapper.jsx';
 import { ChevronRightIcon, ChevronDownIcon } from '@radix-ui/react-icons';
 import IconButton from '../../components/IconButton.jsx';
 import { selectGlobalBreakpoint } from '../projects/projectsSlice.js';
+import { globalBreakpoints } from '../../config.js';
 
 const AdditionalDepCount = styled('div', {
   fontStyle: 'italic',
@@ -169,8 +170,8 @@ const CameraCheckboxLabel = ({ filterCat, managedIds, deployments, activeDeps })
     dispatch(checkboxOnlyButtonClicked({ filterCat, managedIds }));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const alwaysShowOnly = globalBreakpoint === 'xs' || globalBreakpoint === 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const alwaysShowOnly = globalBreakpoints.lessThanOrEqual(currentBreakpoint, 'xs');
 
   return (
     <CheckboxLabel

--- a/src/features/filters/LabelCheckboxLabel.jsx
+++ b/src/features/filters/LabelCheckboxLabel.jsx
@@ -4,6 +4,7 @@ import { styled } from '../../theme/stitches.config';
 import { CheckboxLabel } from '../../components/CheckboxLabel';
 import { checkboxOnlyButtonClicked } from './filtersSlice';
 import { selectGlobalBreakpoint } from '../projects/projectsSlice';
+import { globalBreakpoints } from '../../config';
 
 const OnlyButton = styled('div', {
   background: '$gray3',
@@ -35,8 +36,8 @@ export const LabelCheckboxLabel = ({ id, name, checked, active, filterCat }) => 
     dispatch(checkboxOnlyButtonClicked({ filterCat, managedIds: [id] }));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const alwaysShowOnly = globalBreakpoint === 'xs' || globalBreakpoint === 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const alwaysShowOnly = globalBreakpoints.lessThanOrEqual(currentBreakpoint, 'xs');
 
   return (
     <CheckboxLabel

--- a/src/features/images/ImagesGrid.jsx
+++ b/src/features/images/ImagesGrid.jsx
@@ -39,8 +39,6 @@ const FullSizedImageWrapper = styled('div', {
   display: 'grid',
   placeItems: 'center',
   overflow: 'hidden',
-  borderTop: '4px solid $border',
-  borderBottom: '4px solid $border',
 });
 
 export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
@@ -174,8 +172,8 @@ export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
       }
 
       if (colCount === colCounts.single) {
-        // Image metadata height + top border + bottom border
-        tallest += 40 + 8;
+        // Height of metadata bar
+        tallest += 40;
       }
 
       return tallest;

--- a/src/features/images/ImagesGrid.jsx
+++ b/src/features/images/ImagesGrid.jsx
@@ -14,6 +14,7 @@ import { selectProjectsLoading } from '../projects/projectsSlice.js';
 import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner.jsx';
 import { RatsNoneFound } from './RatsNoneFound.jsx';
 import { FloatingToolbar } from './FloatingToolbar.jsx';
+import { ImageMetadata } from '../loupe/ImageMetadata.jsx';
 
 export const colCounts = {
   single: 1,
@@ -35,10 +36,11 @@ const GridImage = ({ uniqueId, imgUrl, onClickImage, style }) => {
 };
 
 const FullSizedImageWrapper = styled('div', {
-  backgroundColor: 'Black',
   display: 'grid',
   placeItems: 'center',
   overflow: 'hidden',
+  borderTop: '4px solid $border',
+  borderBottom: '4px solid $border',
 });
 
 export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
@@ -129,6 +131,7 @@ export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
       if (colCount === colCounts.single) {
         return (
           <FullSizedImageWrapper key={uniqueRowId} style={style}>
+            <ImageMetadata image={img} />
             <FullSizeImage
               key={uniqueRowId}
               workingImages={workingImages}
@@ -169,6 +172,12 @@ export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
           tallest = scaledHeight;
         }
       }
+
+      if (colCount === colCounts.single) {
+        // Image metadata height + top border + bottom border
+        tallest += 40 + 8;
+      }
+
       return tallest;
     },
     [workingImages, colCount],

--- a/src/features/images/ImagesPanel.jsx
+++ b/src/features/images/ImagesPanel.jsx
@@ -54,14 +54,14 @@ const ImagesPanel = () => {
       : dispatch(fetchImages(activeFilters, 'next'));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
 
   return (
     <StyledImagesPanel>
-      {globalBreakpoint !== 'xxs' && (
+      {currentBreakpoint !== 'xxs' && (
         <ImagesTable workingImages={workingImages} hasNext={hasNext} loadNextPage={loadNextPage} />
       )}
-      {globalBreakpoint === 'xxs' && (
+      {currentBreakpoint === 'xxs' && (
         <ImagesGrid workingImages={workingImages} hasNext={hasNext} loadNextPage={loadNextPage} />
       )}
     </StyledImagesPanel>

--- a/src/features/loupe/BoundingBox.jsx
+++ b/src/features/loupe/BoundingBox.jsx
@@ -26,6 +26,7 @@ import BoundingBoxLabel from './BoundingBoxLabel';
 import { absToRel, relToAbs } from '../../app/utils';
 import { CheckIcon, Cross2Icon, LockOpen1Icon, Pencil1Icon } from '@radix-ui/react-icons';
 import { selectGlobalBreakpoint, selectLabels } from '../projects/projectsSlice';
+import { globalBreakpoints } from '../../config';
 
 const ResizeHandle = styled('div', {
   width: '$3',
@@ -216,8 +217,8 @@ const BoundingBox = ({ imgId, imgDims, object, objectIndex, focusIndex, setTempO
     dispatch(bboxUpdated({ imgId, objId: object._id, bbox }));
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const isSmallScreen = globalBreakpoint === 'xs' || globalBreakpoint === 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const isSmallScreen = globalBreakpoints.lessThanOrEqual(currentBreakpoint, 'xs');
 
   // manage label validation button state
   const [showLabelButtons, setShowLabelButtons] = useState(() => isSmallScreen);

--- a/src/features/loupe/ImageMetadata.jsx
+++ b/src/features/loupe/ImageMetadata.jsx
@@ -24,28 +24,36 @@ const ItemLabel = styled('div', {
 });
 
 const StyledItem = styled('div', {
-  marginLeft: '$5',
   textAlign: 'center',
   flex: '1',
   textWrap: 'nowrap',
+  '@bp1': {
+    marginLeft: '$5',
+  },
 });
 
 const MetadataList = styled('div', {
   display: 'flex',
+  flex: '1',
+  '@bp1': {
+    flex: 'unset',
+  },
 });
 
 const MetadataPane = styled('div', {
   display: 'flex',
   justifyContent: 'center',
-  paddingRight: '$2',
   fontWeight: '$2',
   width: '100%',
+  '@bp1': {
+    paddingRight: '$2',
+  },
 });
 
 const metadataBreakpoints = createBreakpoints([
-  ['xs', 400],
-  ['sm', 500],
-  ['md', 600],
+  ['xs', 500],
+  ['sm', 550],
+  ['md', 700],
   ['lg', Infinity],
 ]);
 
@@ -73,9 +81,11 @@ export const ImageMetadata = ({ image }) => {
   const fullDateCreated = DateTime.fromISO(image.dateTimeOriginal).toLocaleString(
     DateTime.DATETIME_MED_WITH_SECONDS,
   );
-  const dateCreated = isSmallScreen
-    ? DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATETIME_SHORT)
-    : fullDateCreated;
+  const dateCreated = metadataBreakpoints.lessThanOrEqual(breakpoint ?? 'xs', 'xs')
+    ? DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATE_SHORT)
+    : isSmallScreen
+      ? DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATETIME_SHORT)
+      : fullDateCreated;
 
   const cameraId = isSmallScreen ? shortenedField(image.cameraId) : image.cameraId;
 

--- a/src/features/loupe/ImageMetadata.jsx
+++ b/src/features/loupe/ImageMetadata.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { styled } from '../../theme/stitches.config.js';
 import { DateTime } from 'luxon';
 import { createBreakpoints } from '../../app/utils.js';
@@ -43,10 +43,14 @@ const MetadataList = styled('div', {
 const MetadataPane = styled('div', {
   display: 'flex',
   justifyContent: 'center',
+  zIndex: '$4',
   fontWeight: '$2',
   width: '100%',
+  boxShadow: 'rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px',
   '@bp1': {
     paddingRight: '$2',
+    boxShadow: 'unset',
+    zIndex: 'unset',
   },
 });
 
@@ -62,6 +66,30 @@ const shortenedField = (fieldVal) => {
     return fieldVal;
   }
   return `${fieldVal.substring(0, 10)}...`;
+};
+
+const ImageMetadataField = ({ isSmallScreen, label, displayValue, fullValue }) => {
+  const alwaysOpen = !isSmallScreen;
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <StyledItem>
+      <ItemLabel>{label}</ItemLabel>
+      {isSmallScreen ? (
+        <Tooltip onOpenChange={setIsOpen} open={alwaysOpen || isOpen}>
+          <TooltipTrigger asChild>
+            <ItemValue onClick={() => setIsOpen(!isOpen)}>{displayValue}</ItemValue>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {fullValue}
+            <TooltipArrow />
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <ItemValue>{displayValue}</ItemValue>
+      )}
+    </StyledItem>
+  );
 };
 
 export const ImageMetadata = ({ image }) => {
@@ -104,22 +132,13 @@ export const ImageMetadata = ({ image }) => {
     <MetadataPane ref={ref}>
       <MetadataList>
         {metadataItems.map(({ label, displayValue, fullValue }, idx) => (
-          <StyledItem key={idx}>
-            <ItemLabel>{label}</ItemLabel>
-            {isSmallScreen ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <ItemValue>{displayValue}</ItemValue>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {fullValue}
-                  <TooltipArrow />
-                </TooltipContent>
-              </Tooltip>
-            ) : (
-              <ItemValue>{displayValue}</ItemValue>
-            )}
-          </StyledItem>
+          <ImageMetadataField
+            key={idx}
+            isSmallScreen={isSmallScreen}
+            label={label}
+            displayValue={displayValue}
+            fullValue={fullValue}
+          />
         ))}
       </MetadataList>
     </MetadataPane>

--- a/src/features/loupe/ImageMetadata.jsx
+++ b/src/features/loupe/ImageMetadata.jsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { styled } from '../../theme/stitches.config.js';
 import { DateTime } from 'luxon';
-import { createBreakpoints } from '../../app/utils.js';
-import useBreakpoints from '../../hooks/useBreakpoints.js';
+import { selectGlobalBreakpoint } from '../projects/projectsSlice.js';
+import { globalBreakpoints } from '../../config.js';
 import {
   Tooltip,
   TooltipArrow,
   TooltipContent,
   TooltipTrigger,
 } from '../../components/Tooltip.jsx';
+import { useSelector } from 'react-redux';
 
 const ItemValue = styled('div', {
   fontSize: '$3',
@@ -35,8 +36,10 @@ const StyledItem = styled('div', {
 const MetadataList = styled('div', {
   display: 'flex',
   flex: '1',
+  padding: '0 $2',
   '@bp1': {
     flex: 'unset',
+    padding: 'unset',
   },
 });
 
@@ -54,18 +57,11 @@ const MetadataPane = styled('div', {
   },
 });
 
-const metadataBreakpoints = createBreakpoints([
-  ['xs', 500],
-  ['sm', 550],
-  ['md', 700],
-  ['lg', Infinity],
-]);
-
 const shortenedField = (fieldVal) => {
-  if (fieldVal.length <= 10) {
+  if (fieldVal.length <= 8) {
     return fieldVal;
   }
-  return `${fieldVal.substring(0, 10)}...`;
+  return `${fieldVal.substring(0, 5)}...`;
 };
 
 const ImageMetadataField = ({ isSmallScreen, label, displayValue, fullValue }) => {
@@ -101,19 +97,17 @@ export const ImageMetadata = ({ image }) => {
     deploymentName: image.deploymentName ?? '',
   };
 
-  const { ref, breakpoint } = useBreakpoints(metadataBreakpoints.values);
-  const isSmallScreen = metadataBreakpoints.lessThanOrEqual(breakpoint ?? 'xs', 'md');
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const isSmallScreen = globalBreakpoints.lessThanOrEqual(currentBreakpoint ?? 'xs', 'md');
 
   const filename = isSmallScreen ? shortenedField(image.originalFileName) : image.originalFileName;
 
   const fullDateCreated = DateTime.fromISO(image.dateTimeOriginal).toLocaleString(
     DateTime.DATETIME_MED_WITH_SECONDS,
   );
-  const dateCreated = metadataBreakpoints.lessThanOrEqual(breakpoint ?? 'xs', 'xs')
-    ? DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATE_SHORT)
-    : isSmallScreen
-      ? DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATETIME_SHORT)
-      : fullDateCreated;
+  const dateCreated = isSmallScreen
+    ? DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATETIME_SHORT)
+    : fullDateCreated;
 
   const cameraId = isSmallScreen ? shortenedField(image.cameraId) : image.cameraId;
 
@@ -129,7 +123,7 @@ export const ImageMetadata = ({ image }) => {
   ];
 
   return (
-    <MetadataPane ref={ref}>
+    <MetadataPane>
       <MetadataList>
         {metadataItems.map(({ label, displayValue, fullValue }, idx) => (
           <ImageMetadataField

--- a/src/features/loupe/ImageMetadata.jsx
+++ b/src/features/loupe/ImageMetadata.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { styled } from '../../theme/stitches.config.js';
+import { DateTime } from 'luxon';
+// import { useSelector } from 'react-redux';
+// import { selectGlobalBreakpoint } from '../projects/projectsSlice.js';
+
+const ItemValue = styled('div', {
+  fontSize: '$3',
+  fontFamily: '$sourceSansPro',
+  color: '$textDark',
+});
+
+const ItemLabel = styled('div', {
+  fontSize: '$1',
+  color: '$textLight',
+  fontFamily: '$mono',
+  marginBottom: '$1',
+});
+
+const StyledItem = styled('div', {
+  marginLeft: '$5',
+  textAlign: 'center',
+});
+
+const MetadataList = styled('div', {
+  display: 'flex',
+  flexWrap: 'wrap',
+});
+
+const MetadataPane = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  paddingRight: '$2',
+  fontWeight: '$2',
+});
+
+export const ImageMetadata = ({ image }) => {
+  // const globalBreakpoint = useSelector(selectGlobalBreakpoint);
+
+  const dateCreated =
+    image &&
+    DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+
+  const metadataItems = [
+    { label: 'Date created', value: dateCreated },
+    { label: 'Camera', value: image.cameraId },
+    { label: 'Deployment', value: image.deploymentName },
+    { label: 'File name', value: image.originalFileName },
+  ];
+
+  return (
+    <MetadataPane>
+      <MetadataList>
+        {metadataItems.map(({ label, value }, idx) => (
+          <StyledItem key={idx}>
+            <ItemLabel>{label}</ItemLabel>
+            <ItemValue>{value}</ItemValue>
+          </StyledItem>
+        ))}
+      </MetadataList>
+    </MetadataPane>
+  );
+};

--- a/src/features/loupe/Loupe.jsx
+++ b/src/features/loupe/Loupe.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { actions as undoActions } from 'redux-undo-redo';
 import { styled } from '../../theme/stitches.config.js';
-import { DateTime } from 'luxon';
 import {
   selectWorkingImages,
   selectFocusIndex,
@@ -23,48 +22,8 @@ import PanelHeader from '../../components/PanelHeader.jsx';
 import FullSizeImage from './FullSizeImage.jsx';
 import ImageReviewToolbar from './ImageReviewToolbar.jsx';
 import ShareImageButton from './ShareImageButton';
-import LoupeDropdown from './LoupeDropdown.jsx';
 import { ImageTagsToolbar } from './ImageTagsToolbar.jsx';
-
-const ItemValue = styled('div', {
-  fontSize: '$3',
-  fontFamily: '$sourceSansPro',
-  color: '$textDark',
-});
-
-const ItemLabel = styled('div', {
-  fontSize: '$1',
-  color: '$textLight',
-  fontFamily: '$mono',
-  marginBottom: '$1',
-});
-
-const StyledItem = styled('div', {
-  // marginBottom: '$3',
-  marginLeft: '$5',
-  textAlign: 'center',
-});
-
-const Item = ({ label, value }) => (
-  <StyledItem>
-    <ItemLabel>{label}</ItemLabel>
-    <ItemValue>{value}</ItemValue>
-  </StyledItem>
-);
-
-const MetadataList = styled('div', {
-  display: 'flex',
-  flexWrap: 'wrap',
-});
-
-const MetadataPane = styled('div', {
-  // paddingTop: '$3',
-  // marginBottom: '$6',
-  display: 'flex',
-  justifyContent: 'center',
-  paddingRight: '$2',
-  fontWeight: '$2',
-});
+import { ImageMetadata } from './ImageMetadata.jsx';
 
 const ImagePane = styled('div', {
   // display: 'flex',
@@ -225,11 +184,6 @@ const Loupe = () => {
     reviewMode ? dispatch(incrementFocusIndex(delta)) : dispatch(incrementImage(delta));
   };
 
-  // format date created
-  const dtCreated =
-    image &&
-    DateTime.fromISO(image.dateTimeOriginal).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
-
   // Listen for hotkeys
   // TODO: should this all live in the ImageReviewToolbar?
   // TODO: use react synthetic onKeyDown events instead?
@@ -295,17 +249,7 @@ const Loupe = () => {
     <StyledLoupe>
       <LoupeHeader handlePanelClose={handleCloseLoupe} closeButtonPosition="left">
         {image && (
-          <>
-            <MetadataPane>
-              <MetadataList>
-                <Item label="Date created" value={dtCreated} />
-                <Item label="Camera" value={image.cameraId} />
-                <Item label="Deployment" value={image.deploymentName} />
-                <Item label="File name" value={image.originalFileName} />
-              </MetadataList>
-            </MetadataPane>
-            <LoupeDropdown image={image} />
-          </>
+          <ImageMetadata image={image} />
         )}
         {/*<div>
           Label review

--- a/src/features/projects/ViewExplorer.jsx
+++ b/src/features/projects/ViewExplorer.jsx
@@ -10,6 +10,7 @@ import Loupe from '../loupe/Loupe.jsx';
 import ErrorToast from '../../components/ErrorToast.jsx';
 import HydratedModal from '../../components/HydratedModal.jsx';
 import { selectGlobalBreakpoint } from './projectsSlice.js';
+import { globalBreakpoints } from '../../config.js';
 
 const ViewExplorerWrapper = styled('div', {
   display: 'flex',
@@ -33,17 +34,20 @@ const ViewExplorer = () => {
     setFiltersPanelOpen(!filtersPanelOpen);
   };
 
-  const globalBreakpoint = useSelector(selectGlobalBreakpoint);
-  const notXsOrXxs = globalBreakpoint !== 'xs' && globalBreakpoint !== 'xxs';
+  const currentBreakpoint = useSelector(selectGlobalBreakpoint);
+  const isLargeScreen =
+    !currentBreakpoint || globalBreakpoints.greaterThanOrEqual(currentBreakpoint, 'sm');
 
   return (
     <ViewExplorerWrapper>
-      {notXsOrXxs && (
+      {isLargeScreen && (
         <SidebarNav toggleFiltersPanel={toggleFiltersPanel} filtersPanelOpen={filtersPanelOpen} />
       )}
-      {notXsOrXxs && filtersPanelOpen && <FiltersPanel toggleFiltersPanel={toggleFiltersPanel} />}
+      {isLargeScreen && filtersPanelOpen && (
+        <FiltersPanel toggleFiltersPanel={toggleFiltersPanel} />
+      )}
       <ImagesPanel />
-      {notXsOrXxs && loupeOpen && <Loupe />}
+      {isLargeScreen && loupeOpen && <Loupe />}
       <HydratedModal />
       <ErrorToast />
     </ViewExplorerWrapper>


### PR DESCRIPTION
**Context**

Implements #304 

- Refactors the image metedata components into their own component file
- Updates the metadata display based on the screen size
- Adds image metedata to images in the single column grid

Reliant on https://github.com/tnc-ca-geo/animl-frontend/pull/306

**TODO**

- [x] Deploy and test on dev
- [x] Do we need a way to show full filenames, deployment, etc. in the grid? (shown with tooltip on desktop) -- allow tooltips to be clickable on mobile (https://github.com/radix-ui/primitives/issues/1573)