### PR TITLE
Fix image height bug

### DIFF
--- a/src/features/images/ImagesGrid.jsx
+++ b/src/features/images/ImagesGrid.jsx
@@ -158,7 +158,7 @@ export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
       const end = start + colCount;
 
       let tallest = 0;
-      for (let i = 0; i < end; i++) {
+      for (let i = start; i < end; i++) {
         const h = workingImages[i]?.imageHeight ?? defaultWidth * heightModifier;
         const w = workingImages[i]?.imageWidth ?? defaultWidth;
         const scalingFactor = defaultWidth / w;


### PR DESCRIPTION
**Context**
Possibly closes #320 

The loop which calculates image heights in the grid used 0 as the start condition even for images that did not start at the 0th index.  it's now updated to have an accurate start index.

**Commits**

- fix: fix loop start index bug