### PR TITLE
add overflow hidden to floating toolbar

### DIFF
--- a/src/features/images/FloatingToolbar.jsx
+++ b/src/features/images/FloatingToolbar.jsx
@@ -16,6 +16,7 @@ const FloatingToolbarContainer = styled('div', {
   zIndex: '$1',
   boxShadow: '0 16px 32px hsl(206deg 12% 5% / 25%), 0 3px 5px hsl(0deg 0% 0% / 10%)',
   border: '1px solid $border',
+  overflow: 'hidden',
 });
 
 const Separator = styled('div', {


### PR DESCRIPTION
**Context**
The filters icon on the floating toolbar is overflowing on the corners when active