### PR TITLE
Fixes: category selector and height

### DIFF
--- a/src/features/images/ImagesGrid.jsx
+++ b/src/features/images/ImagesGrid.jsx
@@ -253,7 +253,9 @@ export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
                         ref(grid);
                         gridRef.current = grid;
                       }}
-                      height={height}
+                      // Autosizer is consistently setting the height to be
+                      // 1 px taller than its parent
+                      height={height - 1}
                       width={width}
                       columnCount={colCount}
                       columnWidth={() => calcColWidth(width)}

--- a/src/features/images/ImagesTable.jsx
+++ b/src/features/images/ImagesTable.jsx
@@ -288,7 +288,9 @@ const ImagesTable = ({ workingImages, hasNext, loadNextPage }) => {
         >
           {({ onItemsRendered, ref }) => (
             <List
-              height={height - headerHeight}
+              // Autosizer is consistently setting the height to be
+              // 1 px taller than its parent
+              height={height - headerHeight - 1}
               itemCount={imagesCount}
               itemSize={91}
               onItemsRendered={onItemsRendered}

--- a/src/features/loupe/ImageReviewToolbar.jsx
+++ b/src/features/loupe/ImageReviewToolbar.jsx
@@ -147,8 +147,10 @@ const ImageReviewToolbar = ({
   useEffect(() => {
     if (localCatSelectorOpen) {
       setCatSelectorOpen(isAddingLabel === 'from-review-toolbar');
+    } else {
+      setCatSelectorOpen(false);
     }
-    if (isAddingLabel === null) {
+    if (isAddingLabel === null || !localCatSelectorOpen) {
       setLocalCatSelectorOpen(false);
     }
   }, [isAddingLabel, localCatSelectorOpen]);

--- a/src/features/loupe/ImageReviewToolbar.jsx
+++ b/src/features/loupe/ImageReviewToolbar.jsx
@@ -150,7 +150,7 @@ const ImageReviewToolbar = ({
     } else {
       setCatSelectorOpen(false);
     }
-    if (isAddingLabel === null || !localCatSelectorOpen) {
+    if (isAddingLabel === null) {
       setLocalCatSelectorOpen(false);
     }
   }, [isAddingLabel, localCatSelectorOpen]);


### PR DESCRIPTION
**Context**
Fixes the category selector staying 'selected' even after a label is chosen.  Also fixes a 1px scroll that was happening.


**Commits**
- fix: fix cat selector staying open
- fix: fix autosizer being too tall