### PR TITLE
Fix StatsModal breaking when labelList is undefined

### DIFF
--- a/src/features/images/ImagesStatsModal.jsx
+++ b/src/features/images/ImagesStatsModal.jsx
@@ -252,7 +252,7 @@ const ImagesStatsModal = ({ open }) => {
               content={hints.notReviewedCount}
             />
           </div>
-          {Object.keys(stats['labelList']).length !== 0 && (
+          {stats['labelList'] && Object.keys(stats['labelList']).length !== 0 && (
             <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center' }}>
               <GraphCard
                 label="Validated labels"


### PR DESCRIPTION
**Bug:** User goes to filters -> User checks ` unselect all` for any of the categories (deployments, labels, etc)` -> attempts to open StatsModal -> modal and page breaks
<img width="553" alt="Screenshot 2025-06-17 at 11 45 18 AM" src="https://github.com/user-attachments/assets/c81e5913-daa5-48ef-b36b-7f9214e5015b" />

**Changes:**
Checks that `labelList` is not undefined before trying to iterate over keys.

Result now =>
<img width="864" alt="Screenshot 2025-06-17 at 11 59 15 AM" src="https://github.com/user-attachments/assets/a8005e6e-37d3-4108-ba16-6ef493fe7e63" />


