### PR TITLE
Hide horizontal overflow

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,7 +5,7 @@ import { ConnectedRouter } from 'connected-react-router';
 import { Authenticator } from '@aws-amplify/ui-react';
 import { Theme } from '@radix-ui/themes';
 import store, { history } from './app/store';
-import App from './app/App.jsx'
+import App from './app/App.jsx';
 import './assets/fontawesome';
 import '@radix-ui/themes/styles.css';
 
@@ -15,16 +15,15 @@ const render = () => {
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <Authenticator.Provider>
-            <Theme style={{ zIndex: 'auto' }}>
+            <Theme style={{ zIndex: 'auto', overflowX: 'hidden' }}>
               <App />
             </Theme>
           </Authenticator.Provider>
         </ConnectedRouter>
       </Provider>
     </React.StrictMode>,
-    document.getElementById('root')
+    document.getElementById('root'),
   );
 };
 
 render();
-


### PR DESCRIPTION
Fixes an issue in Chrome on Windows in which, when (a) the browser is zoomed in to 110-125%, (b) the Loupe is open, and (c) there's a bounding box abutting the right hand side of the image, the bounding box can extend slightly beyond the right side of the image, which causes the scroll bar to appear and reappear rapidly.

This PR sets the horizontal overflow to hidden to prevent the scrollbar from appearing.