### PR TITLE
Put timestamp adjustment modal behind a feature flag

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,7 @@ export const SUPPORTED_WIRELESS_CAMS = [
 ];
 
 export const IN_MAINTENANCE_MODE = false;
+export const ENABLE_TIMESTAMP_OFFSET = false;
 
 export const GA_CONFIG = {
   trackingId: 'G-V6NSBLL83L',

--- a/src/features/loupe/LoupeDropdown.jsx
+++ b/src/features/loupe/LoupeDropdown.jsx
@@ -16,6 +16,7 @@ import { setDeleteImagesAlertStatus } from '../images/imagesSlice';
 import { selectFocusIndex, setSelectedImageIndices } from '../review/reviewSlice.js';
 import { setModalOpen, setModalContent } from '../projects/projectsSlice.js';
 import { Trash2, Clock } from 'lucide-react';
+import { ENABLE_TIMESTAMP_OFFSET } from '../../config';
 
 const StyledDropdownMenuTrigger = styled(DropdownMenuTrigger, {
   position: 'absolute',
@@ -45,12 +46,14 @@ const LoupeDropdown = ({ image }) => {
         </IconButton>
       </StyledDropdownMenuTrigger>
       <DropdownMenuContent sideOffset={5}>
-        <DropdownMenuItem onSelect={handleEditTimestampClick}>
-          <DropdownMenuItemIconLeft>
-            <Clock size={15} />
-          </DropdownMenuItemIconLeft>
-          Edit Image Timestamp
-        </DropdownMenuItem>
+        {ENABLE_TIMESTAMP_OFFSET && (
+          <DropdownMenuItem onSelect={handleEditTimestampClick}>
+            <DropdownMenuItemIconLeft>
+              <Clock size={15} />
+            </DropdownMenuItemIconLeft>
+            Edit Image Timestamp
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onSelect={handleDeleteImageItemClick}>
           <DropdownMenuItemIconLeft>
             <Trash2 size={15} />


### PR DESCRIPTION
There is a potential problem where setting timestamp offsets should trigger deployment reassignment, but we're not doing that. Add a feature flag for the offset modal and temporarily turn it off.