### PR TITLE
fix: clamp bbox coordinates to prevent negative values on resize

### DIFF
--- a/src/features/loupe/BoundingBox.jsx
+++ b/src/features/loupe/BoundingBox.jsx
@@ -211,7 +211,13 @@ const BoundingBox = ({
     if (handle.indexOf('n') > -1 && top <= 0) setConstraintY(height);
     if (handle.indexOf('s') > -1 && bottom <= 0) setConstraintY(height);
 
-    const rect = { left, top, width: size.width, height: size.height };
+    // Clamp coordinates to image bounds to prevent negative bbox values (#220)
+    left = Math.max(0, left);
+    top = Math.max(0, top);
+    const clampedWidth = Math.max(1, Math.min(size.width, imgDims.width - left));
+    const clampedHeight = Math.max(1, Math.min(size.height, imgDims.height - top));
+
+    const rect = { left, top, width: clampedWidth, height: clampedHeight };
     const newBbox = absToRel(rect, imgDims);
     setBbox(newBbox);
   };


### PR DESCRIPTION
When resizing bounding boxes (especially from the north/west handles), coordinates could escape image bounds, producing invalid bbox data where xmax is less than xmin. This broke downstream ML processing. The fix clamps left, top, width, and height to stay within the image after every resize event, so bounding boxes always have valid positive dimensions.

Closes #220

<!-- DCCE:AI-BEGIN
{
  "dcceVersion": "0.1",
  "id": "0125c75e-a2b2-4464-9380-02ebd00c2611",
  "contentType": "pr_description",
  "ai": {
    "issue": "#220",
    "root_cause": "onResize handler in BoundingBox.jsx did not clamp left/top after n/w handle adjustment, allowing negative coordinates and bbox inversions",
    "fix": "Added Math.max/Math.min clamping for left>=0, top>=0, width>=1 and <=remaining, height>=1 and <=remaining after handle repositioning",
    "files_changed": ["src/features/loupe/BoundingBox.jsx"],
    "lines_added": 7,
    "lines_removed": 1,
    "risk": "low",
    "testing": "manual resize from all 4 corner handles, rapid mouse movement past image edges"
  },
  "provenance": {
    "actor": "ai",
    "tool": "M7 MCP",
    "model": "claude-4.6-opus",
    "generatedAt": "2026-02-09T18:35:14.581Z"
  }
}
DCCE:AI-END -->

Made with [Cursor](https://cursor.com)