### PR TITLE
Admin dashboard v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.1",
         "@fortawesome/react-fontawesome": "^0.1.11",
         "@juggle/resize-observer": "^3.3.1",
+        "@mapbox/search-js-react": "^1.5.1",
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/react-alert-dialog": "^1.0.4",
         "@radix-ui/react-context-menu": "^2.1.5",
@@ -81,6 +82,7 @@
         "react-with-direction": "^1.3.1",
         "recharts": "^2.12.3",
         "redux-undo-redo": "^2.1.1",
+        "tz-lookup": "^6.1.25",
         "use-resize-observer": "^9.1.0",
         "yup": "^0.32.8"
       },
@@ -6203,6 +6205,82 @@
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
       "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
       "license": "ISC"
+    },
+    "node_modules/@mapbox/search-js-core": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/search-js-core/-/search-js-core-1.5.1.tgz",
+      "integrity": "sha512-aXv9LoN8FvTkMhOOWxIEwFsh8aZFMid1xZfGD71nxWGEWG+TufjCdMCExOI/q7XI49xR1+kEc3ONI21X484uow==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@types/geojson": "^7946.0.8"
+      },
+      "engines": {
+        "node": ">=12.20.1"
+      }
+    },
+    "node_modules/@mapbox/search-js-react": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/search-js-react/-/search-js-react-1.5.1.tgz",
+      "integrity": "sha512-+5t7WkAOhpVvqWF9A+BZYEjkFaZ6i5lvLwkXqV5a/UrpsHCCDpcg2Ii5TKvtCJ1GW7VVnCocDH2aF49tIvtM2g==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@mapbox/search-js-core": "^1.5.1",
+        "@mapbox/search-js-web": "^1.5.1",
+        "@types/geojson": "^7946.0.8"
+      },
+      "engines": {
+        "node": ">=12.20.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@mapbox/search-js-web": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/search-js-web/-/search-js-web-1.5.1.tgz",
+      "integrity": "sha512-hhPbcbamv8Mzitzwgzzxac7GA1TUW5S4aKGDdDkOgbgTyoudunSm4Jem364yxv4bJi4dPFk+WSyhNdF1m5VCkw==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@floating-ui/dom": "^0.5.2",
+        "@mapbox/search-js-core": "^1.5.1",
+        "@mapbox/sphericalmercator": "^1.2.0",
+        "focus-trap": "^6.7.3",
+        "no-scroll": "^2.1.1",
+        "subtag": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12.20.1"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=2.7.0"
+      }
+    },
+    "node_modules/@mapbox/search-js-web/node_modules/@floating-ui/core": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==",
+      "license": "MIT"
+    },
+    "node_modules/@mapbox/search-js-web/node_modules/@floating-ui/dom": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.5.4.tgz",
+      "integrity": "sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^0.7.3"
+      }
+    },
+    "node_modules/@mapbox/sphericalmercator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.2.0.tgz",
+      "integrity": "sha512-ZTOuuwGuMOJN+HEmG/68bSEw15HHaMWmQ5gdTsWdWsjDe56K1kGvLOK6bOSC8gWgIvEO0w6un/2Gvv1q5hJSkQ==",
+      "bin": {
+        "bbox": "bin/bbox.js",
+        "to4326": "bin/to4326.js",
+        "to900913": "bin/to900913.js",
+        "xyz": "bin/xyz.js"
+      }
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "2.0.7",
@@ -17970,6 +18048,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/focus-trap": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+      "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^5.3.3"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -21134,6 +21221,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/no-scroll": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/no-scroll/-/no-scroll-2.1.1.tgz",
+      "integrity": "sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -23818,6 +23911,12 @@
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
     },
+    "node_modules/subtag": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/subtag/-/subtag-0.5.0.tgz",
+      "integrity": "sha512-CaIBcTSb/nyk4xiiSOtZYz1B+F12ZxW8NEp54CdT+84vmh/h4sUnHGC6+KQXUfED8u22PQjCYWfZny8d2ELXwg==",
+      "license": "ISC"
+    },
     "node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
@@ -23854,6 +23953,12 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
+    },
+    "node_modules/tabbable": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+      "license": "MIT"
     },
     "node_modules/tar-stream": {
       "version": "1.6.2",
@@ -24274,6 +24379,12 @@
       "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
       "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
       "license": "MIT"
+    },
+    "node_modules/tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==",
+      "license": "CC0-1.0"
     },
     "node_modules/ulid": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@juggle/resize-observer": "^3.3.1",
+    "@mapbox/search-js-react": "^1.5.1",
     "@radix-ui/colors": "^0.1.8",
     "@radix-ui/react-alert-dialog": "^1.0.4",
     "@radix-ui/react-context-menu": "^2.1.5",
@@ -75,6 +76,7 @@
     "react-with-direction": "^1.3.1",
     "recharts": "^2.12.3",
     "redux-undo-redo": "^2.1.1",
+    "tz-lookup": "^6.1.25",
     "use-resize-observer": "^9.1.0",
     "yup": "^0.32.8"
   },

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -246,6 +246,19 @@ const queries = {
     variables: { input: input },
   }),
 
+  updateProject: (input) => ({
+    template: `
+      mutation UpdateProject($input: UpdateProjectInput!) {
+        updateProject(input: $input) {
+          project {
+            ${projectFields}
+          }
+        }
+      }
+    `,
+    variables: { input: input },
+  }),
+
   getViews: () => ({
     template: `
       {

--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -176,6 +176,18 @@ const projectFields = `
   name
   timezone
   description
+  type
+  stage
+  organization
+  country
+  state_province
+  location {
+    _id
+    geometry {
+      type
+      coordinates
+    }
+  }
   views {
     ${viewFields}
   }

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -29,7 +29,6 @@ const AppContainer = styled('div', {
   display: 'grid',
   gridTemplateRows: 'auto 1fr',
   gridTemplateColumns: '100%',
-  height: '100vh',
 });
 
 const MainenanceMessage = styled('div', {

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { ResizeObserver } from '@juggle/resize-observer';
+import { ObjectID } from 'bson';
 
 /*
  * Hook for skiping the useEffect run on a component's initial render
@@ -169,6 +170,20 @@ export const isImageReviewed = (image) => {
     obj.labels.some((lbl) => !lbl.validation || lbl.validation.validated),
   );
   return hasObjs && !hasUnlockedObjs && !hasAllInvalidatedLabels;
+};
+
+// Factory to create breakpoints and utility methods
+/*
+ * build a GeoJSON location object from lat/lon
+ */
+export const buildLocation = (lat, lon) => {
+  return {
+    _id: new ObjectID().toString(),
+    geometry: {
+      type: 'Point',
+      coordinates: [lon, lat],
+    },
+  };
 };
 
 // Factory to create breakpoints and utility methods

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -172,7 +172,6 @@ export const isImageReviewed = (image) => {
   return hasObjs && !hasUnlockedObjs && !hasAllInvalidatedLabels;
 };
 
-// Factory to create breakpoints and utility methods
 /*
  * build a GeoJSON location object from lat/lon
  */

--- a/src/components/ErrorToast.jsx
+++ b/src/components/ErrorToast.jsx
@@ -20,6 +20,8 @@ import {
   dismissModelsError,
   selectCreateProjectsErrors,
   dismissCreateProjectError,
+  selectUpdateProjectErrors,
+  dismissUpdateProjectError,
   selectManageLabelsErrors,
   dismissManageLabelsError,
   selectProjectTagErrors,
@@ -84,6 +86,7 @@ const ErrorToast = () => {
   const redriveBatchErrors = useSelector(selectRedriveBatchErrors);
   const manageUserErrors = useSelector(selectManageUserErrors);
   const createProjectErrors = useSelector(selectCreateProjectsErrors);
+  const updateProjectErrors = useSelector(selectUpdateProjectErrors);
   const manageLabelsErrors = useSelector(selectManageLabelsErrors);
   const uploadErrors = useSelector(selectUploadErrors);
   const cameraSerialNumberErrors = useSelector(selectCameraSerialNumberErrors);
@@ -111,6 +114,7 @@ const ErrorToast = () => {
     enrichErrors(redriveBatchErrors, 'Error Retrying Failed Images in Batch', 'redriveBatch'),
     enrichErrors(manageUserErrors, 'Manage User Error', 'manageUsers'),
     enrichErrors(createProjectErrors, 'Error Creating Project', 'createProject'),
+    enrichErrors(updateProjectErrors, 'Error Updating Project', 'updateProject'),
     enrichErrors(manageLabelsErrors, 'Error Updating Label', 'manageLabels'),
     enrichErrors(uploadErrors, 'Error Uploading Images', 'upload'),
     enrichErrors(
@@ -174,6 +178,7 @@ const dismissErrorActions = {
   comments: (i) => dismissCommentsError(i),
   projects: (i) => dismissProjectsError(i),
   createProject: (i) => dismissCreateProjectError(i),
+  updateProject: (i) => dismissUpdateProjectError(i),
   views: (i) => dismissViewsError(i),
   deployments: (i) => dismissDeploymentsError(i),
   models: (i) => dismissModelsError(i),

--- a/src/components/LocationPicker.jsx
+++ b/src/components/LocationPicker.jsx
@@ -1,0 +1,198 @@
+import React, { useState, useCallback } from 'react';
+import MapGL, { Marker, NavigationControl } from 'react-map-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+import { styled } from '../theme/stitches.config.js';
+import { MAPBOX_TOKEN } from '../config.js';
+import { FormFieldWrapper, FormError } from './Form.jsx';
+
+const MapContainer = styled('div', {
+  width: '100%',
+  height: '300px',
+  borderRadius: '$2',
+  overflow: 'hidden',
+  marginBottom: '$2',
+  cursor: 'crosshair',
+});
+
+const CoordinateInputs = styled('div', {
+  display: 'flex',
+  gap: '$3',
+});
+
+const MarkerPin = styled('div', {
+  width: '16px',
+  height: '16px',
+  borderRadius: '$round',
+  backgroundColor: '$blue500',
+  border: '3px solid white',
+  boxShadow: '0 2px 6px rgba(0, 0, 0, 0.3)',
+  transform: 'translate(-50%, -50%)',
+});
+
+const FallbackNote = styled('p', {
+  color: '$textLight',
+  fontSize: '$3',
+  margin: '0 0 $2 0',
+});
+
+const LocationPicker = ({
+  latitude,
+  longitude,
+  setFieldValue,
+  setFieldTouched,
+  errors,
+  touched,
+}) => {
+  const [viewState, setViewState] = useState({
+    longitude: 0,
+    latitude: 20,
+    zoom: 1,
+  });
+
+  const hasMarker = latitude !== '' && longitude !== '' && !isNaN(latitude) && !isNaN(longitude);
+
+  const handleMapClick = useCallback(
+    (e) => {
+      const { lng, lat } = e.lngLat;
+      setFieldValue('latitude', parseFloat(lat.toFixed(6)));
+      setFieldValue('longitude', parseFloat(lng.toFixed(6)));
+      setFieldTouched('latitude', true);
+      setFieldTouched('longitude', true);
+    },
+    [setFieldValue, setFieldTouched],
+  );
+
+  const handleMarkerDragEnd = useCallback(
+    (e) => {
+      const { lng, lat } = e.lngLat;
+      setFieldValue('latitude', parseFloat(lat.toFixed(6)));
+      setFieldValue('longitude', parseFloat(lng.toFixed(6)));
+    },
+    [setFieldValue],
+  );
+
+  const handleLatChange = useCallback(
+    (e) => {
+      const val = e.target.value;
+      setFieldValue('latitude', val === '' ? '' : parseFloat(val) || val);
+      if (val !== '' && !isNaN(val) && longitude !== '' && !isNaN(longitude)) {
+        setViewState((prev) => ({
+          ...prev,
+          latitude: parseFloat(val),
+          longitude: parseFloat(longitude),
+        }));
+      }
+    },
+    [setFieldValue, longitude],
+  );
+
+  const handleLngChange = useCallback(
+    (e) => {
+      const val = e.target.value;
+      setFieldValue('longitude', val === '' ? '' : parseFloat(val) || val);
+      if (val !== '' && !isNaN(val) && latitude !== '' && !isNaN(latitude)) {
+        setViewState((prev) => ({
+          ...prev,
+          longitude: parseFloat(val),
+          latitude: parseFloat(latitude),
+        }));
+      }
+    },
+    [setFieldValue, latitude],
+  );
+
+  if (!MAPBOX_TOKEN) {
+    return (
+      <>
+        <FallbackNote>Map unavailable — enter coordinates manually.</FallbackNote>
+        <CoordinateInputs>
+          <FormFieldWrapper>
+            <label htmlFor="latitude">Latitude</label>
+            <input
+              id="latitude"
+              name="latitude"
+              type="number"
+              step="any"
+              value={latitude}
+              onChange={handleLatChange}
+              onBlur={() => setFieldTouched('latitude', true)}
+            />
+            {!!errors.latitude && touched.latitude && <FormError>{errors.latitude}</FormError>}
+          </FormFieldWrapper>
+          <FormFieldWrapper>
+            <label htmlFor="longitude">Longitude</label>
+            <input
+              id="longitude"
+              name="longitude"
+              type="number"
+              step="any"
+              value={longitude}
+              onChange={handleLngChange}
+              onBlur={() => setFieldTouched('longitude', true)}
+            />
+            {!!errors.longitude && touched.longitude && <FormError>{errors.longitude}</FormError>}
+          </FormFieldWrapper>
+        </CoordinateInputs>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <MapContainer>
+        <MapGL
+          {...viewState}
+          onMove={(e) => setViewState(e.viewState)}
+          onClick={handleMapClick}
+          mapboxAccessToken={MAPBOX_TOKEN}
+          mapStyle="mapbox://styles/mapbox/light-v11"
+          style={{ width: '100%', height: '100%' }}
+          reuseMaps
+        >
+          <NavigationControl position="top-right" />
+          {hasMarker && (
+            <Marker
+              longitude={parseFloat(longitude)}
+              latitude={parseFloat(latitude)}
+              anchor="center"
+              draggable
+              onDragEnd={handleMarkerDragEnd}
+            >
+              <MarkerPin />
+            </Marker>
+          )}
+        </MapGL>
+      </MapContainer>
+      <CoordinateInputs>
+        <FormFieldWrapper>
+          <label htmlFor="latitude">Latitude</label>
+          <input
+            id="latitude"
+            name="latitude"
+            type="number"
+            step="any"
+            value={latitude}
+            onChange={handleLatChange}
+            onBlur={() => setFieldTouched('latitude', true)}
+          />
+          {!!errors.latitude && touched.latitude && <FormError>{errors.latitude}</FormError>}
+        </FormFieldWrapper>
+        <FormFieldWrapper>
+          <label htmlFor="longitude">Longitude</label>
+          <input
+            id="longitude"
+            name="longitude"
+            type="number"
+            step="any"
+            value={longitude}
+            onChange={handleLngChange}
+            onBlur={() => setFieldTouched('longitude', true)}
+          />
+          {!!errors.longitude && touched.longitude && <FormError>{errors.longitude}</FormError>}
+        </FormFieldWrapper>
+      </CoordinateInputs>
+    </>
+  );
+};
+
+export default LocationPicker;

--- a/src/components/LocationPicker.jsx
+++ b/src/components/LocationPicker.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import MapGL, { Marker, NavigationControl } from 'react-map-gl';
+import { SearchBox } from '@mapbox/search-js-react';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { styled } from '../theme/stitches.config.js';
 import { MAPBOX_TOKEN } from '../config.js';
@@ -50,6 +51,35 @@ const LocationPicker = ({
   });
 
   const hasMarker = latitude !== '' && longitude !== '' && !isNaN(latitude) && !isNaN(longitude);
+
+  const handleSearchRetrieve = useCallback(
+    (res) => {
+      const feature = res?.features?.[0];
+      if (!feature) return;
+
+      const [lng, lat] = feature.geometry.coordinates;
+      setFieldValue('latitude', parseFloat(lat.toFixed(6)));
+      setFieldValue('longitude', parseFloat(lng.toFixed(6)));
+      setFieldTouched('latitude', true);
+      setFieldTouched('longitude', true);
+
+      setViewState((prev) => ({
+        ...prev,
+        longitude: lng,
+        latitude: lat,
+        zoom: 12,
+      }));
+
+      const context = feature.properties?.context;
+      if (context?.country?.name) {
+        setFieldValue('country', context.country.name);
+      }
+      if (context?.region?.name) {
+        setFieldValue('state_province', context.region.name);
+      }
+    },
+    [setFieldValue, setFieldTouched],
+  );
 
   const handleMapClick = useCallback(
     (e) => {
@@ -145,11 +175,25 @@ const LocationPicker = ({
           onMove={(e) => setViewState(e.viewState)}
           onClick={handleMapClick}
           mapboxAccessToken={MAPBOX_TOKEN}
-          mapStyle="mapbox://styles/mapbox/light-v11"
+          mapStyle="mapbox://styles/mapbox/satellite-v9"
           style={{ width: '100%', height: '100%' }}
           reuseMaps
         >
-          <NavigationControl position="top-right" />
+          <div style={{ padding: '10px' }}>
+            <SearchBox
+              accessToken={MAPBOX_TOKEN}
+              onRetrieve={handleSearchRetrieve}
+              theme={{
+                cssText: `
+
+                .Input {
+                  padding-left: 2.25em !important;
+                }
+              `,
+              }}
+            />
+          </div>
+          <NavigationControl position="bottom-right" />
           {hasMarker && (
             <Marker
               longitude={parseFloat(longitude)}

--- a/src/components/SelectField.jsx
+++ b/src/components/SelectField.jsx
@@ -74,6 +74,7 @@ const SelectField = ({
   isMulti,
   maxMenuHeight = 400,
   menuPlacement = 'auto',
+  components: customComponents,
 }) => {
   const handleChange = (value) => {
     onChange(name, value);
@@ -105,6 +106,7 @@ const SelectField = ({
         isMulti={isMulti}
         maxMenuHeight={maxMenuHeight}
         menuPlacement={menuPlacement}
+        {...(customComponents && { components: customComponents })}
       />
       {!!error && touched && <FormError>{error}</FormError>}
     </div>

--- a/src/features/admin/ProjectMap.jsx
+++ b/src/features/admin/ProjectMap.jsx
@@ -127,7 +127,7 @@ const ProjectMap = () => {
           <MapGL
             initialViewState={initialViewState}
             mapboxAccessToken={MAPBOX_TOKEN}
-            mapStyle="mapbox://styles/mapbox/light-v11"
+            mapStyle="mapbox://styles/mapbox/satellite-v9"
             style={{ width: '100%', height: '100%' }}
             reuseMaps
           >

--- a/src/features/cameras/SaveDeploymentForm.jsx
+++ b/src/features/cameras/SaveDeploymentForm.jsx
@@ -19,6 +19,7 @@ import {
 } from '../../components/Form.jsx';
 import DatePickerWithFormik from '../../components/DatePicker.jsx';
 import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner.jsx';
+import { buildLocation } from '../../app/utils.js';
 
 const FormHeader = styled('div', {
   fontWeight: '$3',
@@ -272,16 +273,6 @@ const updateGloablTimezone = (tz) => {
     moment.tz.setDefault();
   }
 };
-
-function buildLocation(lat, lon) {
-  return {
-    _id: new ObjectID().toString(),
-    geometry: {
-      type: 'Point',
-      coordinates: [lon, lat],
-    },
-  };
-}
 
 function diff(formVals, deployment) {
   const depLat = deployment.location.geometry.coordinates[1];

--- a/src/features/projects/CreateProjectForm.jsx
+++ b/src/features/projects/CreateProjectForm.jsx
@@ -14,7 +14,9 @@ import {
 } from '../../components/Form';
 import Button from '../../components/Button.jsx';
 import SelectField from '../../components/SelectField.jsx';
+import LocationPicker from '../../components/LocationPicker.jsx';
 import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner.jsx';
+import { buildLocation } from '../../app/utils.js';
 
 import {
   createProject,
@@ -39,10 +41,35 @@ const Header = styled('div', {
   marginBottom: '$4',
 });
 
+const typeOptions = [
+  { value: 'internal', label: 'Internal' },
+  { value: 'external', label: 'External' },
+];
+
+const stageOptions = [
+  { value: 'demo', label: 'Demo' },
+  { value: 'production', label: 'Production' },
+];
+
 const createProjectSchema = Yup.object().shape({
   name: Yup.string().required('Enter a project name'),
   description: Yup.string().required('Enter a short description'),
+  type: Yup.string().required('Select a project type'),
+  stage: Yup.string().required('Select a project stage'),
+  organization: Yup.string().required('Enter an organization'),
+  country: Yup.string().required('Enter a country'),
+  state_province: Yup.string().required('Enter a state/province'),
   timezone: Yup.string().required('Select a timezone'),
+  latitude: Yup.number()
+    .required('Select a location on the map')
+    .test('is-decimal', 'Coordinates must be in decimal degrees', (value) =>
+      (value + '').match(/^-?[0-9]\d*(\.\d+)?$/),
+    ),
+  longitude: Yup.number()
+    .required('Select a location on the map')
+    .test('is-decimal', 'Coordinates must be in decimal degrees', (value) =>
+      (value + '').match(/^-?[0-9]\d*(\.\d+)?$/),
+    ),
   availableMLModels: Yup.array()
     .min(1, 'Select at least one ML model')
     .required('Select a ML model'),
@@ -81,14 +108,29 @@ const CreateProjectForm = () => {
           initialValues={{
             name: '',
             description: '',
+            type: '',
+            stage: '',
+            organization: '',
+            country: '',
+            state_province: '',
             timezone: '',
+            latitude: '',
+            longitude: '',
             availableMLModels: [],
           }}
           validationSchema={createProjectSchema}
-          onSubmit={(values, { resetForm }) => dispatch(createProject(values, resetForm))}
+          onSubmit={(values, { resetForm }) => {
+            const { latitude, longitude, ...rest } = values;
+            const payload = {
+              ...rest,
+              location: buildLocation(parseFloat(latitude), parseFloat(longitude)),
+            };
+            dispatch(createProject(payload, resetForm));
+          }}
         >
           {({ values, errors, isValid, touched, setFieldTouched, setFieldValue }) => (
             <Form>
+              {/* Project identity */}
               <FieldRow>
                 <FormFieldWrapper>
                   <label htmlFor="name">Name</label>
@@ -108,6 +150,61 @@ const CreateProjectForm = () => {
               <FieldRow>
                 <FormFieldWrapper>
                   <SelectField
+                    name="type"
+                    label="Type"
+                    options={typeOptions}
+                    value={typeOptions.find(({ value }) => value === values.type)}
+                    touched={touched.type}
+                    onChange={(name, { value }) => setFieldValue(name, value)}
+                    onBlur={(name) => setFieldTouched(name, true)}
+                    error={errors.type}
+                  />
+                </FormFieldWrapper>
+              </FieldRow>
+              <FieldRow>
+                <FormFieldWrapper>
+                  <SelectField
+                    name="stage"
+                    label="Stage"
+                    options={stageOptions}
+                    value={stageOptions.find(({ value }) => value === values.stage)}
+                    touched={touched.stage}
+                    onChange={(name, { value }) => setFieldValue(name, value)}
+                    onBlur={(name) => setFieldTouched(name, true)}
+                    error={errors.stage}
+                  />
+                </FormFieldWrapper>
+              </FieldRow>
+              <FieldRow>
+                <FormFieldWrapper>
+                  <label htmlFor="organization">Organization</label>
+                  <Field name="organization" id="organization" />
+                  {!!errors.organization && touched.organization && (
+                    <FormError>{errors.organization}</FormError>
+                  )}
+                </FormFieldWrapper>
+              </FieldRow>
+
+              {/* Geography */}
+              <FieldRow>
+                <FormFieldWrapper>
+                  <label htmlFor="country">Country</label>
+                  <Field name="country" id="country" />
+                  {!!errors.country && touched.country && <FormError>{errors.country}</FormError>}
+                </FormFieldWrapper>
+              </FieldRow>
+              <FieldRow>
+                <FormFieldWrapper>
+                  <label htmlFor="state_province">State / Province</label>
+                  <Field name="state_province" id="state_province" />
+                  {!!errors.state_province && touched.state_province && (
+                    <FormError>{errors.state_province}</FormError>
+                  )}
+                </FormFieldWrapper>
+              </FieldRow>
+              <FieldRow>
+                <FormFieldWrapper>
+                  <SelectField
                     name="timezone"
                     label="Timezone"
                     options={tzOptions}
@@ -120,6 +217,23 @@ const CreateProjectForm = () => {
                   />
                 </FormFieldWrapper>
               </FieldRow>
+
+              {/* Location */}
+              <FieldRow>
+                <FormFieldWrapper>
+                  <label>Location</label>
+                  <LocationPicker
+                    latitude={values.latitude}
+                    longitude={values.longitude}
+                    setFieldValue={setFieldValue}
+                    setFieldTouched={setFieldTouched}
+                    errors={errors}
+                    touched={touched}
+                  />
+                </FormFieldWrapper>
+              </FieldRow>
+
+              {/* ML models */}
               <FieldRow>
                 <FormFieldWrapper>
                   <SelectField

--- a/src/features/projects/CreateProjectForm.jsx
+++ b/src/features/projects/CreateProjectForm.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Formik, Form, Field } from 'formik';
+import { Formik, Form, Field, useFormikContext } from 'formik';
 import * as Yup from 'yup';
 import { timeZonesNames } from '@vvo/tzdb';
+import tzlookup from 'tz-lookup';
 
 import { styled } from '../../theme/stitches.config.js';
 import {
@@ -40,6 +41,50 @@ const Header = styled('div', {
   paddingTop: '$8',
   marginBottom: '$4',
 });
+
+const TimezoneHint = styled('div', {
+  fontSize: '$2',
+  color: '$textLight',
+  marginTop: '$1',
+  fontStyle: 'italic',
+});
+
+const TimezoneAutoFill = ({ setInferredTimezone }) => {
+  const { values, setFieldValue } = useFormikContext();
+  const timerRef = useRef(null);
+  const prevInferredRef = useRef(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    const lat = parseFloat(values.latitude);
+    const lng = parseFloat(values.longitude);
+
+    if (isNaN(lat) || isNaN(lng)) {
+      setInferredTimezone(null);
+      return;
+    }
+
+    timerRef.current = setTimeout(() => {
+      try {
+        const tz = tzlookup(lat, lng);
+        if (timeZonesNames.includes(tz)) {
+          setInferredTimezone(tz);
+          if (values.timezone === '' || values.timezone === prevInferredRef.current) {
+            setFieldValue('timezone', tz);
+          }
+          prevInferredRef.current = tz;
+        }
+      } catch {
+        // tz-lookup throws on out-of-bounds coordinates
+      }
+    }, 500);
+
+    return () => clearTimeout(timerRef.current);
+  }, [values.latitude, values.longitude]);
+
+  return null;
+};
 
 const typeOptions = [
   { value: 'internal', label: 'Internal' },
@@ -80,6 +125,7 @@ const CreateProjectForm = () => {
   const mlModels = useSelector(selectModelOptions);
   const createProjectIsLoading = useSelector(selectCreateProjectLoading);
   const mlModelsOptionsIsLoading = useSelector(selectModelOptionsLoading);
+  const [inferredTimezone, setInferredTimezone] = useState(null);
 
   const tzOptions = timeZonesNames.map((tz) => ({ value: tz, label: tz }));
   const mlModelOptions = useMemo(
@@ -130,6 +176,7 @@ const CreateProjectForm = () => {
         >
           {({ values, errors, isValid, touched, setFieldTouched, setFieldValue }) => (
             <Form>
+              <TimezoneAutoFill setInferredTimezone={setInferredTimezone} />
               {/* Project identity */}
               <FieldRow>
                 <FormFieldWrapper>
@@ -185,6 +232,21 @@ const CreateProjectForm = () => {
                 </FormFieldWrapper>
               </FieldRow>
 
+              {/* Location */}
+              <FieldRow>
+                <FormFieldWrapper>
+                  <label>Location</label>
+                  <LocationPicker
+                    latitude={values.latitude}
+                    longitude={values.longitude}
+                    setFieldValue={setFieldValue}
+                    setFieldTouched={setFieldTouched}
+                    errors={errors}
+                    touched={touched}
+                  />
+                </FormFieldWrapper>
+              </FieldRow>
+
               {/* Geography */}
               <FieldRow>
                 <FormFieldWrapper>
@@ -202,6 +264,8 @@ const CreateProjectForm = () => {
                   )}
                 </FormFieldWrapper>
               </FieldRow>
+
+              {/* Timezone (after location for auto-inference) */}
               <FieldRow>
                 <FormFieldWrapper>
                   <SelectField
@@ -210,26 +274,18 @@ const CreateProjectForm = () => {
                     options={tzOptions}
                     value={tzOptions.find(({ value }) => value === values.timezone)}
                     touched={touched.timezone}
-                    onChange={(name, { value }) => setFieldValue(name, value)}
-                    onBlur={(name, { value }) => setFieldTouched(name, value)}
+                    onChange={(name, { value }) => {
+                      setFieldValue(name, value);
+                    }}
+                    onBlur={(name, { value }) => {
+                      setFieldTouched(name, value);
+                    }}
                     error={errors.timezone}
                     maxMenuHeight={300}
                   />
-                </FormFieldWrapper>
-              </FieldRow>
-
-              {/* Location */}
-              <FieldRow>
-                <FormFieldWrapper>
-                  <label>Location</label>
-                  <LocationPicker
-                    latitude={values.latitude}
-                    longitude={values.longitude}
-                    setFieldValue={setFieldValue}
-                    setFieldTouched={setFieldTouched}
-                    errors={errors}
-                    touched={touched}
-                  />
+                  {inferredTimezone && (
+                    <TimezoneHint>Timezone at current Location is: {inferredTimezone}</TimezoneHint>
+                  )}
                 </FormFieldWrapper>
               </FieldRow>
 

--- a/src/features/projects/CreateProjectForm.jsx
+++ b/src/features/projects/CreateProjectForm.jsx
@@ -74,7 +74,7 @@ const TimezoneAutoFill = ({ setInferredTimezone }) => {
     }, 500);
 
     return () => clearTimeout(timerRef.current);
-  }, [values.latitude, values.longitude]);
+  }, [values.latitude, values.longitude, values.timezone, setFieldValue, setInferredTimezone]);
 
   return null;
 };
@@ -88,6 +88,8 @@ const stageOptions = [
   { value: 'demo', label: 'Demo' },
   { value: 'production', label: 'Production' },
 ];
+
+const tzOptions = timeZonesNames.map((tz) => ({ value: tz, label: tz }));
 
 const createProjectSchema = Yup.object().shape({
   name: Yup.string().required('Enter a project name'),
@@ -120,7 +122,6 @@ const CreateProjectForm = () => {
   const mlModelsOptionsIsLoading = useSelector(selectModelOptionsLoading);
   const [inferredTimezone, setInferredTimezone] = useState(null);
 
-  const tzOptions = timeZonesNames.map((tz) => ({ value: tz, label: tz }));
   const mlModelOptions = useMemo(
     () =>
       mlModels.map(({ _id, description }) => ({

--- a/src/features/projects/CreateProjectForm.jsx
+++ b/src/features/projects/CreateProjectForm.jsx
@@ -27,13 +27,6 @@ import {
   selectModelOptionsLoading,
 } from './projectsSlice.js';
 
-const PageWrapper = styled('div', {
-  maxWidth: '600px',
-  padding: '0 $5',
-  width: '100%',
-  margin: '0 auto',
-});
-
 const Header = styled('div', {
   fontSize: '24px',
   fontWeight: '$5',
@@ -142,13 +135,13 @@ const CreateProjectForm = () => {
   }, []);
 
   return (
-    <PageWrapper>
+    <>
       {(createProjectIsLoading || mlModelsOptionsIsLoading) && (
         <SpinnerOverlay>
           <SimpleSpinner />
         </SpinnerOverlay>
       )}
-      <Header>Create project</Header>
+      <Header>Create Project</Header>
       <FormWrapper>
         <Formik
           initialValues={{
@@ -322,7 +315,7 @@ const CreateProjectForm = () => {
           )}
         </Formik>
       </FormWrapper>
-    </PageWrapper>
+    </>
   );
 };
 

--- a/src/features/projects/EditProjectForm.jsx
+++ b/src/features/projects/EditProjectForm.jsx
@@ -77,7 +77,7 @@ const TimezoneAutoFill = ({ setInferredTimezone }) => {
     }, 500);
 
     return () => clearTimeout(timerRef.current);
-  }, [values.latitude, values.longitude]);
+  }, [values.latitude, values.longitude, values.timezone, setFieldValue, setInferredTimezone]);
 
   return null;
 };
@@ -91,6 +91,8 @@ const stageOptions = [
   { value: 'demo', label: 'Demo' },
   { value: 'production', label: 'Production' },
 ];
+
+const tzOptions = timeZonesNames.map((tz) => ({ value: tz, label: tz }));
 
 const editProjectSchema = Yup.object().shape({
   name: Yup.string().required('Enter a project name'),
@@ -224,7 +226,6 @@ const EditProjectForm = () => {
     [projects],
   );
 
-  const tzOptions = timeZonesNames.map((tz) => ({ value: tz, label: tz }));
   const mlModelOptions = useMemo(
     () =>
       mlModels.map(({ _id, description }) => ({

--- a/src/features/projects/EditProjectForm.jsx
+++ b/src/features/projects/EditProjectForm.jsx
@@ -1,0 +1,449 @@
+import React, { useEffect, useMemo, useState, useRef, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Formik, Form, Field, useFormikContext } from 'formik';
+import * as Yup from 'yup';
+import { timeZonesNames } from '@vvo/tzdb';
+import tzlookup from 'tz-lookup';
+import { components } from 'react-select';
+import { styled } from '../../theme/stitches.config.js';
+import {
+  FormWrapper,
+  FormFieldWrapper,
+  FieldRow,
+  ButtonRow,
+  FormError,
+} from '../../components/Form';
+import Button from '../../components/Button.jsx';
+import SelectField from '../../components/SelectField.jsx';
+import LocationPicker from '../../components/LocationPicker.jsx';
+import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner.jsx';
+import { buildLocation } from '../../app/utils.js';
+
+import {
+  fetchProjects,
+  fetchModelOptions,
+  updateProject,
+  selectProjects,
+  selectProjectsLoading,
+  selectModelOptions,
+  selectModelOptionsLoading,
+  selectUpdateProjectLoading,
+} from './projectsSlice.js';
+
+const Header = styled('div', {
+  fontSize: '24px',
+  fontWeight: '$5',
+  fontFamily: '$roboto',
+  paddingTop: '$8',
+  marginBottom: '$4',
+});
+
+const TimezoneHint = styled('div', {
+  fontSize: '$2',
+  color: '$textLight',
+  marginTop: '$1',
+  fontStyle: 'italic',
+});
+
+const TimezoneAutoFill = ({ setInferredTimezone }) => {
+  const { values, setFieldValue } = useFormikContext();
+  const timerRef = useRef(null);
+  const prevInferredRef = useRef(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    const lat = parseFloat(values.latitude);
+    const lng = parseFloat(values.longitude);
+
+    if (isNaN(lat) || isNaN(lng)) {
+      setInferredTimezone(null);
+      return;
+    }
+
+    timerRef.current = setTimeout(() => {
+      try {
+        const tz = tzlookup(lat, lng);
+        if (timeZonesNames.includes(tz)) {
+          setInferredTimezone(tz);
+          if (values.timezone === '' || values.timezone === prevInferredRef.current) {
+            setFieldValue('timezone', tz);
+          }
+          prevInferredRef.current = tz;
+        }
+      } catch {
+        // tz-lookup throws on out-of-bounds coordinates
+      }
+    }, 500);
+
+    return () => clearTimeout(timerRef.current);
+  }, [values.latitude, values.longitude]);
+
+  return null;
+};
+
+const typeOptions = [
+  { value: 'internal', label: 'Internal' },
+  { value: 'external', label: 'External' },
+];
+
+const stageOptions = [
+  { value: 'demo', label: 'Demo' },
+  { value: 'production', label: 'Production' },
+];
+
+const editProjectSchema = Yup.object().shape({
+  name: Yup.string().required('Enter a project name'),
+  description: Yup.string().required('Enter a short description'),
+  type: Yup.string().required('Select a project type'),
+  stage: Yup.string().required('Select a project stage'),
+  organization: Yup.string().required('Enter an organization'),
+  country: Yup.string().required('Enter a country'),
+  state_province: Yup.string().required('Enter a state/province'),
+  timezone: Yup.string().required('Select a timezone'),
+  latitude: Yup.number()
+    .required('Select a location on the map')
+    .test('is-decimal', 'Coordinates must be in decimal degrees', (value) =>
+      (value + '').match(/^-?[0-9]\d*(\.\d+)?$/),
+    ),
+  longitude: Yup.number()
+    .required('Select a location on the map')
+    .test('is-decimal', 'Coordinates must be in decimal degrees', (value) =>
+      (value + '').match(/^-?[0-9]\d*(\.\d+)?$/),
+    ),
+  availableMLModels: Yup.array()
+    .min(1, 'Select at least one ML model')
+    .required('Select a ML model'),
+});
+
+function diffProject(formVals, originalProject) {
+  const diffs = {};
+  if (formVals.name !== originalProject.name) diffs.name = formVals.name;
+  if (formVals.description !== originalProject.description)
+    diffs.description = formVals.description;
+  if (formVals.type !== originalProject.type) diffs.type = formVals.type;
+  if (formVals.stage !== originalProject.stage) diffs.stage = formVals.stage;
+  if (formVals.organization !== originalProject.organization)
+    diffs.organization = formVals.organization;
+  if (formVals.country !== originalProject.country) diffs.country = formVals.country;
+  if (formVals.state_province !== originalProject.state_province)
+    diffs.state_province = formVals.state_province;
+  if (formVals.timezone !== originalProject.timezone) diffs.timezone = formVals.timezone;
+
+  const origLat = originalProject.location?.geometry?.coordinates?.[1];
+  const origLng = originalProject.location?.geometry?.coordinates?.[0];
+  if (parseFloat(formVals.latitude) !== origLat || parseFloat(formVals.longitude) !== origLng) {
+    diffs.location = buildLocation(parseFloat(formVals.latitude), parseFloat(formVals.longitude));
+  }
+
+  const origModels = [...(originalProject.availableMLModels || [])].sort();
+  const currentModels = [...formVals.availableMLModels].sort();
+  if (JSON.stringify(origModels) !== JSON.stringify(currentModels)) {
+    diffs.availableMLModels = formVals.availableMLModels;
+  }
+
+  return diffs;
+}
+
+function projectToFormValues(project) {
+  return {
+    name: project.name || '',
+    description: project.description || '',
+    type: project.type || '',
+    stage: project.stage || '',
+    organization: project.organization || '',
+    country: project.country || '',
+    state_province: project.state_province || '',
+    timezone: project.timezone || '',
+    latitude: project.location?.geometry?.coordinates?.[1] ?? '',
+    longitude: project.location?.geometry?.coordinates?.[0] ?? '',
+    availableMLModels: project.availableMLModels || [],
+  };
+}
+
+// Hide remove button for existing ML model chips
+const NonRemovableMultiValueRemove = (existingModelIds) => {
+  return function MultiValueRemove(props) {
+    if (existingModelIds.has(props.data.value)) {
+      return null;
+    }
+    return <components.MultiValueRemove {...props} />;
+  };
+};
+
+const EditProjectForm = () => {
+  const dispatch = useDispatch();
+  const projects = useSelector(selectProjects);
+  const projectsLoading = useSelector(selectProjectsLoading);
+  const mlModels = useSelector(selectModelOptions);
+  const mlModelsOptionsIsLoading = useSelector(selectModelOptionsLoading);
+  const updateProjectIsLoading = useSelector(selectUpdateProjectLoading);
+  const [selectedProjectId, setSelectedProjectId] = useState(null);
+  const [inferredTimezone, setInferredTimezone] = useState(null);
+
+  const selectedProject = useMemo(
+    () => projects.find((p) => p._id === selectedProjectId),
+    [projects, selectedProjectId],
+  );
+
+  const initialValues = useMemo(
+    () =>
+      selectedProject
+        ? projectToFormValues(selectedProject)
+        : {
+            name: '',
+            description: '',
+            type: '',
+            stage: '',
+            organization: '',
+            country: '',
+            state_province: '',
+            timezone: '',
+            latitude: '',
+            longitude: '',
+            availableMLModels: [],
+          },
+    [selectedProject],
+  );
+
+  const existingModelIds = useMemo(
+    () => new Set(selectedProject?.availableMLModels || []),
+    [selectedProject],
+  );
+
+  const mlModelComponents = useMemo(
+    () => ({ MultiValueRemove: NonRemovableMultiValueRemove(existingModelIds) }),
+    [existingModelIds],
+  );
+
+  const projectOptions = useMemo(
+    () =>
+      projects
+        .filter((p) => p._id !== 'default_project')
+        .map((p) => ({ value: p._id, label: p.name })),
+    [projects],
+  );
+
+  const tzOptions = timeZonesNames.map((tz) => ({ value: tz, label: tz }));
+  const mlModelOptions = useMemo(
+    () =>
+      mlModels.map(({ _id, description }) => ({
+        value: _id,
+        label: description,
+      })),
+    [mlModels],
+  );
+
+  useEffect(() => {
+    dispatch(fetchProjects());
+    dispatch(fetchModelOptions());
+  }, []);
+
+  const handleProjectSelect = useCallback(
+    (name, { value }) => {
+      setSelectedProjectId(value);
+      dispatch(fetchProjects({ _ids: [value] }));
+    },
+    [dispatch],
+  );
+
+  const isLoading = projectsLoading.isLoading || mlModelsOptionsIsLoading || updateProjectIsLoading;
+
+  return (
+    <>
+      {isLoading && (
+        <SpinnerOverlay>
+          <SimpleSpinner />
+        </SpinnerOverlay>
+      )}
+      <Header>Edit Project</Header>
+      <FormWrapper>
+        <FieldRow>
+          <FormFieldWrapper>
+            <SelectField
+              name="projectSelector"
+              label="Select a Project"
+              options={projectOptions}
+              value={projectOptions.find(({ value }) => value === selectedProjectId)}
+              touched={false}
+              onChange={handleProjectSelect}
+              onBlur={() => {}}
+              error={null}
+              isSearchable
+            />
+          </FormFieldWrapper>
+        </FieldRow>
+
+        {selectedProject && (
+          <Formik
+            key={selectedProjectId}
+            initialValues={initialValues}
+            enableReinitialize
+            validationSchema={editProjectSchema}
+            onSubmit={(values) => {
+              const diffs = diffProject(values, selectedProject);
+              if (Object.keys(diffs).length === 0) return;
+              dispatch(
+                updateProject(selectedProjectId, diffs, () => {
+                  dispatch(fetchProjects({ _ids: [selectedProjectId] }));
+                }),
+              );
+            }}
+          >
+            {({ values, errors, isValid, dirty, touched, setFieldTouched, setFieldValue }) => (
+              <Form>
+                <TimezoneAutoFill setInferredTimezone={setInferredTimezone} />
+                {/* Project identity */}
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <label htmlFor="name">Name</label>
+                    <Field name="name" id="name" />
+                    {!!errors.name && touched.name && <FormError>{errors.name}</FormError>}
+                  </FormFieldWrapper>
+                </FieldRow>
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <label htmlFor="description">Description</label>
+                    <Field as="textarea" name="description" id="description" />
+                    {!!errors.description && touched.description && (
+                      <FormError>{errors.description}</FormError>
+                    )}
+                  </FormFieldWrapper>
+                </FieldRow>
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <SelectField
+                      name="type"
+                      label="Type"
+                      options={typeOptions}
+                      value={typeOptions.find(({ value }) => value === values.type)}
+                      touched={touched.type}
+                      onChange={(name, { value }) => setFieldValue(name, value)}
+                      onBlur={(name) => setFieldTouched(name, true)}
+                      error={errors.type}
+                    />
+                  </FormFieldWrapper>
+                </FieldRow>
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <SelectField
+                      name="stage"
+                      label="Stage"
+                      options={stageOptions}
+                      value={stageOptions.find(({ value }) => value === values.stage)}
+                      touched={touched.stage}
+                      onChange={(name, { value }) => setFieldValue(name, value)}
+                      onBlur={(name) => setFieldTouched(name, true)}
+                      error={errors.stage}
+                    />
+                  </FormFieldWrapper>
+                </FieldRow>
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <label htmlFor="organization">Organization</label>
+                    <Field name="organization" id="organization" />
+                    {!!errors.organization && touched.organization && (
+                      <FormError>{errors.organization}</FormError>
+                    )}
+                  </FormFieldWrapper>
+                </FieldRow>
+
+                {/* Location */}
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <label>Location</label>
+                    <LocationPicker
+                      latitude={values.latitude}
+                      longitude={values.longitude}
+                      setFieldValue={setFieldValue}
+                      setFieldTouched={setFieldTouched}
+                      errors={errors}
+                      touched={touched}
+                    />
+                  </FormFieldWrapper>
+                </FieldRow>
+
+                {/* Geography */}
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <label htmlFor="country">Country</label>
+                    <Field name="country" id="country" />
+                    {!!errors.country && touched.country && <FormError>{errors.country}</FormError>}
+                  </FormFieldWrapper>
+                </FieldRow>
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <label htmlFor="state_province">State / Province</label>
+                    <Field name="state_province" id="state_province" />
+                    {!!errors.state_province && touched.state_province && (
+                      <FormError>{errors.state_province}</FormError>
+                    )}
+                  </FormFieldWrapper>
+                </FieldRow>
+
+                {/* Timezone */}
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <SelectField
+                      name="timezone"
+                      label="Timezone"
+                      options={tzOptions}
+                      value={tzOptions.find(({ value }) => value === values.timezone)}
+                      touched={touched.timezone}
+                      onChange={(name, { value }) => setFieldValue(name, value)}
+                      onBlur={(name) => setFieldTouched(name, true)}
+                      error={errors.timezone}
+                      maxMenuHeight={300}
+                    />
+                    {inferredTimezone && (
+                      <TimezoneHint>
+                        Timezone at current Location is: {inferredTimezone}
+                      </TimezoneHint>
+                    )}
+                  </FormFieldWrapper>
+                </FieldRow>
+
+                {/* ML models (add-only) */}
+                <FieldRow>
+                  <FormFieldWrapper>
+                    <SelectField
+                      name="availableMLModels"
+                      label="Available ML models"
+                      options={mlModelOptions}
+                      value={mlModelOptions.filter(({ value }) =>
+                        values.availableMLModels.includes(value),
+                      )}
+                      touched={touched.availableMLModels}
+                      onChange={(name, value) => {
+                        const newIds = value.map((v) => v.value);
+                        // Ensure existing models are never removed
+                        const merged = [
+                          ...existingModelIds,
+                          ...newIds.filter((id) => !existingModelIds.has(id)),
+                        ];
+                        setFieldValue(name, merged);
+                      }}
+                      onBlur={(name) => setFieldTouched(name, true)}
+                      error={errors.availableMLModels}
+                      maxMenuHeight={300}
+                      isMulti
+                      components={mlModelComponents}
+                    />
+                  </FormFieldWrapper>
+                </FieldRow>
+
+                <ButtonRow>
+                  <Button type="submit" size="large" disabled={!isValid || !dirty}>
+                    Save changes
+                  </Button>
+                </ButtonRow>
+              </Form>
+            )}
+          </Formik>
+        )}
+      </FormWrapper>
+    </>
+  );
+};
+
+export default EditProjectForm;

--- a/src/features/projects/projectsSlice.js
+++ b/src/features/projects/projectsSlice.js
@@ -57,6 +57,11 @@ const initialState = {
       operation: null,
       errors: null,
     },
+    updateProject: {
+      isLoading: false,
+      operation: null,
+      errors: null,
+    },
   },
   successNotif: {
     title: '',
@@ -161,6 +166,33 @@ export const projectsSlice = createSlice({
     dismissCreateProjectError: (state, { payload }) => {
       const index = payload;
       state.loadingStates.createProject.errors.splice(index, 1);
+    },
+
+    updateProjectStart: (state) => {
+      const ls = { isLoading: true, operation: 'updating', errors: null };
+      state.loadingStates.updateProject = ls;
+    },
+
+    updateProjectSuccess: (state, { payload }) => {
+      const { project } = payload.updateProject;
+      const ls = { isLoading: false, operation: null, errors: null };
+      state.loadingStates.updateProject = ls;
+      const idx = state.projects.findIndex((p) => p._id === project._id);
+      if (idx !== -1) state.projects[idx] = project;
+      state.successNotif = {
+        title: 'Updated Project',
+        message: 'Project updated successfully!',
+      };
+    },
+
+    updateProjectFailure: (state, { payload }) => {
+      const ls = { isLoading: false, operation: null, errors: payload };
+      state.loadingStates.updateProject = ls;
+    },
+
+    dismissUpdateProjectError: (state, { payload }) => {
+      const index = payload;
+      state.loadingStates.updateProject.errors.splice(index, 1);
     },
 
     /*
@@ -520,6 +552,11 @@ export const {
   createProjectFailure,
   dismissCreateProjectError,
 
+  updateProjectStart,
+  updateProjectSuccess,
+  updateProjectFailure,
+  dismissUpdateProjectError,
+
   editViewStart,
   saveViewSuccess,
   deleteViewSuccess,
@@ -610,6 +647,26 @@ export const createProject = (payload, resetFormCallback) => async (dispatch) =>
   } catch (err) {
     console.log('err: ', err);
     dispatch(createProjectFailure(err));
+  }
+};
+
+export const updateProject = (projId, diffs, successCallback) => async (dispatch) => {
+  try {
+    const currentUser = await Auth.currentAuthenticatedUser();
+    const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
+    if (token) {
+      dispatch(updateProjectStart());
+      const result = await call({
+        projId,
+        request: 'updateProject',
+        input: diffs,
+      });
+      dispatch(updateProjectSuccess(result));
+      if (successCallback) successCallback();
+    }
+  } catch (err) {
+    console.log('err: ', err);
+    dispatch(updateProjectFailure(err));
   }
 };
 
@@ -992,5 +1049,9 @@ export const selectManageLabelsErrors = (state) =>
 export const selectProjectTagErrors = (state) => state.projects.loadingStates.projectTags.errors;
 export const selectAutomationRules = (state) => state.projects.automationRules;
 export const selectProjectSuccessNotif = (state) => state.projects.successNotif;
+export const selectUpdateProjectLoading = (state) =>
+  state.projects.loadingStates.updateProject.isLoading;
+export const selectUpdateProjectErrors = (state) =>
+  state.projects.loadingStates.updateProject.errors;
 
 export default projectsSlice.reducer;

--- a/src/features/projects/projectsSlice.js
+++ b/src/features/projects/projectsSlice.js
@@ -152,7 +152,7 @@ export const projectsSlice = createSlice({
       state.loadingStates.createProject = ls;
 
       state.projects = [...state.projects, project];
-      state.successNotifs = {
+      state.successNotif = {
         title: 'Created Project',
         message: 'Project created successfully!',
       };

--- a/src/pages/CreateProjectPage.jsx
+++ b/src/pages/CreateProjectPage.jsx
@@ -1,29 +1,94 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { styled } from '../theme/stitches.config.js';
 import { Page } from '../components/Page.jsx';
-import { NotFound } from '../components/NotFound.jsx'
-import { selectUserUsername, selectUserAuthStatus, selectUserIsSuperUser } from '../features/auth/authSlice.js';
+import { NotFound } from '../components/NotFound.jsx';
+import {
+  selectUserUsername,
+  selectUserAuthStatus,
+  selectUserIsSuperUser,
+} from '../features/auth/authSlice.js';
 import LoginForm from '../features/auth/LoginForm.jsx';
 import CreateProjectForm from '../features/projects/CreateProjectForm.jsx';
+import EditProjectForm from '../features/projects/EditProjectForm.jsx';
 import SuccessToast from '../components/SuccessToast.jsx';
+import ErrorToast from '../components/ErrorToast.jsx';
+
+const PageWrapper = styled('div', {
+  maxWidth: '600px',
+  padding: '0 $5',
+  width: '100%',
+  margin: '0 auto',
+});
+
+const TabBar = styled('div', {
+  display: 'flex',
+  gap: '$3',
+  paddingTop: '$8',
+  borderBottom: '1px solid $border',
+});
+
+const Tab = styled('button', {
+  padding: '$2 $4',
+  fontSize: '$4',
+  fontWeight: '$5',
+  fontFamily: '$roboto',
+  cursor: 'pointer',
+  background: 'none',
+  border: 'none',
+  borderBottom: '2px solid transparent',
+  color: '$textMedium',
+  marginBottom: '-1px',
+  '&:hover': {
+    color: '$textDark',
+  },
+  variants: {
+    active: {
+      true: {
+        color: '$blue500',
+        borderBottomColor: '$blue500',
+      },
+    },
+  },
+});
 
 const CreateProjectPage = () => {
   const authStatus = useSelector(selectUserAuthStatus);
   const user = useSelector(selectUserUsername);
   const isSuperUser = useSelector(selectUserIsSuperUser);
   const signedIn = authStatus === 'authenticated' && user;
+  const [activeTab, setActiveTab] = useState('create');
 
   if (!signedIn) {
-    return <Page><LoginForm /></Page>;
+    return (
+      <Page>
+        <LoginForm />
+      </Page>
+    );
   }
 
   return (
     <Page>
-      {isSuperUser ? <CreateProjectForm /> : <NotFound />}
+      {isSuperUser ? (
+        <PageWrapper>
+          <TabBar>
+            <Tab active={activeTab === 'create'} onClick={() => setActiveTab('create')}>
+              Create Project
+            </Tab>
+            <Tab active={activeTab === 'edit'} onClick={() => setActiveTab('edit')}>
+              Edit Project
+            </Tab>
+          </TabBar>
+          {activeTab === 'create' ? <CreateProjectForm /> : <EditProjectForm />}
+        </PageWrapper>
+      ) : (
+        <NotFound />
+      )}
       <SuccessToast />
+      <ErrorToast />
     </Page>
-  )
-}
+  );
+};
 
 export default CreateProjectPage;


### PR DESCRIPTION
## Pull Request: Admin Dashboard v2

Sibling of: https://github.com/tnc-ca-geo/animl-api/pull/389

### Overview
Adds new fields to the project data model, a Mapbox-powered location picker, and a full Edit Project form for superusers.

---

### Changes

#### New: Location Picker component (LocationPicker.jsx)
- Reusable Mapbox map component with click-to-place marker, draggable marker, and bidirectional lat/lng text inputs
- Integrates `@mapbox/search-js-react` SearchBox for address/place search
- Auto-fills `country` and `state_province` fields from search result context
- Gracefully degrades to plain text inputs when `MAPBOX_TOKEN` is unavailable

#### Updated: Create Project form (CreateProjectForm.jsx)
Added 6 new required fields to project creation:
- **Type** (internal / external) — dropdown
- **Stage** (demo / production) — dropdown
- **Organization** — text
- **Location** — map picker (lat/lng → GeoJSON `LocationInput`)
- **Country** / **State/Province** — text, auto-filled by location search
- **Timezone** — dropdown with automatic inference from selected coordinates via `tz-lookup`

#### New: Edit Project form (EditProjectForm.jsx)
- Superuser-only form for editing existing projects, integrated into the Create Project page via a tab UI
- Project selector dropdown fetches fresh data for the selected project before pre-filling all fields
- Submits only changed fields (diff-based), matching the pattern used in `SaveDeploymentForm`
- **`availableMLModels` is add-only**: existing model chips render without a remove button; the `onChange` handler enforces that existing models are always preserved in the submitted value

#### Updated: Create Project page (CreateProjectPage.jsx)
- Added tab UI to switch between **Create Project** and **Edit Project** forms
- Both tabs remain gated behind the `isSuperUser` check

#### Backend wiring
- buildQuery.js: Added `type`, `stage`, `organization`, `country`, `state_province`, and `location` to the `projectFields` GraphQL fragment; added `updateProject` mutation template
- projectsSlice.js: Added `updateProject` loading state, `updateProjectStart/Success/Failure` reducers (success patches in-place by `_id` and fires a success notification), `updateProject` async thunk, and `selectUpdateProjectLoading` / `selectUpdateProjectErrors` selectors
- `ErrorToast.jsx`: Wired in `updateProject` error path
- utils.js: Extracted `buildLocation()` helper (previously local to `SaveDeploymentForm`) to shared utils; `SaveDeploymentForm` updated to import it from there

#### Misc
- `App.jsx`: Removed `height: 100vh` from `AppContainer` to fix layout on taller pages
- Added `@mapbox/search-js-react` and `tz-lookup` as dependencies