### PR TITLE
Button to temporarily hide bounding boxes

### DIFF
--- a/src/features/loupe/FullSizeImage.jsx
+++ b/src/features/loupe/FullSizeImage.jsx
@@ -25,7 +25,7 @@ const ImageFrame = styled('div', {
   position: 'absolute',
 });
 
-const FullSizeImage = ({ workingImages, image, focusIndex }) => {
+const FullSizeImage = ({ workingImages, image, focusIndex, bboxesVisible = true }) => {
   const isDrawingBbox = useSelector(selectIsDrawingBbox);
 
   // track image loading state
@@ -85,7 +85,8 @@ const FullSizeImage = ({ workingImages, image, focusIndex }) => {
             height: imgDims.height,
           }}
         >
-          {objectsToRender &&
+          {bboxesVisible &&
+            objectsToRender &&
             objectsToRender.map((obj) => {
               return (
                 <BoundingBox
@@ -100,7 +101,7 @@ const FullSizeImage = ({ workingImages, image, focusIndex }) => {
                 />
               );
             })}
-          {isDrawingBbox && (
+          {bboxesVisible && isDrawingBbox && (
             <DrawBboxOverlay
               imgContainerDims={imgContainerDims}
               imgDims={imgDims}

--- a/src/features/loupe/ImageReviewToolbar.jsx
+++ b/src/features/loupe/ImageReviewToolbar.jsx
@@ -12,6 +12,8 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   ChatBubbleIcon,
+  DotsHorizontalIcon,
+  ClipboardCopyIcon,
 } from '@radix-ui/react-icons';
 import IconButton from '../../components/IconButton.jsx';
 import {
@@ -19,7 +21,12 @@ import {
   setMobileCategorySelectorFocus,
   setMobileCommentFocusIndex,
 } from '../review/reviewSlice.js';
-import { addLabelStart, selectIsDrawingBbox, selectIsAddingLabel } from './loupeSlice.js';
+import {
+  addLabelStart,
+  selectIsDrawingBbox,
+  selectIsAddingLabel,
+  copyUrlToClipboard,
+} from './loupeSlice.js';
 import { selectUserUsername, selectUserCurrentRoles } from '../auth/authSlice.js';
 import {
   hasRole,
@@ -27,7 +34,7 @@ import {
   READ_COMMENTS_ROLES,
   WRITE_COMMENTS_ROLES,
 } from '../auth/roles.js';
-import { selectGlobalBreakpoint } from '../projects/projectsSlice.js';
+import { selectGlobalBreakpoint, selectSelectedProject } from '../projects/projectsSlice.js';
 import { violet, mauve, indigo } from '@radix-ui/colors';
 import Button from '../../components/Button.jsx';
 import { KeyboardKeyHint } from '../../components/KeyboardKeyHint.jsx';
@@ -40,12 +47,24 @@ import {
 } from '../../components/Tooltip.jsx';
 import { globalBreakpoints } from '../../config.js';
 import { CommentsPopover } from './CommentsPopover.jsx';
-import ShareImageButton from './ShareImageButton.jsx';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuItemIconLeft,
+} from '../../components/Dropdown.jsx';
+import {
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastAction,
+  ToastViewport,
+} from '../../components/Toast.jsx';
+import { truncateString } from '../../app/utils.js';
 
 const Badge = styled('div', {
-  position: 'absolute',
-  top: 1,
-  left: 18,
+  marginLeft: '$1',
   background: indigo.indigo4,
   fontSize: '$1',
   fontWeight: '$5',
@@ -138,7 +157,17 @@ const ImageReviewToolbar = ({
   const userRoles = useSelector(selectUserCurrentRoles);
   const userId = useSelector(selectUserUsername);
   const isDrawingBbox = useSelector(selectIsDrawingBbox);
+  const selectedProject = useSelector(selectSelectedProject);
   const dispatch = useDispatch();
+
+  // Copy URL state and handler (for mobile overflow menu)
+  const [showCopyToast, setShowCopyToast] = useState(false);
+  const handleCopyUrl = () => {
+    const allImagesView = selectedProject.views.find((v) => v.name === 'All images');
+    const shareURL = `${window.location.origin}/app/${selectedProject._id}/${allImagesView._id}?img=${image._id}`;
+    dispatch(copyUrlToClipboard(shareURL));
+    setShowCopyToast(true);
+  };
 
   // manage category selector state (open/closed)
   const isAddingLabel = useSelector(selectIsAddingLabel);
@@ -193,206 +222,241 @@ const ImageReviewToolbar = ({
     : {};
 
   return (
-    <Toolbar
-      // overflow x is needed because the toolbar is too wide on mobile
-      // overflow x automatically sets overflow y which hides the
-      // category menu
-      css={toolbarScrollCss}
-    >
-      {hasRole(userRoles, WRITE_OBJECTS_ROLES) && (
-        <AnnotationControls>
-          {/* Repeat last action */}
-          {!isSmallScreen && (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <ToolbarIconButton onClick={handleRepeatAction} disabled={!lastAction}>
-                    <ReloadIcon />
-                  </ToolbarIconButton>
-                </TooltipTrigger>
-                <TooltipContent side="top" sideOffset={5}>
-                  Repeat last action
-                  <TooltipArrow />
-                </TooltipContent>
-              </Tooltip>
-
-              <Separator />
-            </>
-          )}
-
-          {/* Edit */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {!isSmallScreen && catSelectorOpen ? (
-                <CategorySelector handleCategoryChange={handleCategoryChange} />
-              ) : (
-                <ToolbarIconButton
-                  onClick={handleEditAllLabelsButtonClick}
-                  disabled={allObjectsLocked || image.awaitingPrediction}
-                >
-                  <Pencil1Icon />
-                </ToolbarIconButton>
-              )}
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={5}>
-              Edit all labels
-              <TooltipArrow />
-            </TooltipContent>
-          </Tooltip>
-
-          <Separator />
-
-          {/* Validate/invalidate */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                onClick={(e) => handleValidateAllButtonClick(e, true)}
-                disabled={allObjectsLocked || image.awaitingPrediction}
-              >
-                <CheckIcon />
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={5}>
-              Validate all labels
-              <TooltipArrow />
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                onClick={(e) => handleValidateAllButtonClick(e, false)}
-                disabled={allObjectsLocked || image.awaitingPrediction}
-              >
-                <Cross2Icon />
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={5}>
-              Invalidate all labels
-              <TooltipArrow />
-            </TooltipContent>
-          </Tooltip>
-
-          <Separator />
-
-          {/* Mark empty */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                onClick={handleMarkEmptyButtonClick}
-                disabled={image.awaitingPrediction}
-              >
-                <ValueNoneIcon />
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={5}>
-              Mark empty
-              <TooltipArrow />
-            </TooltipContent>
-          </Tooltip>
-
-          <Separator />
-
-          {/* Add object */}
-          {!isSmallScreen && (
-            <>
-              {isDrawingBbox ? (
-                <CancelHint>
-                  <KeyboardKeyHint css={{ marginRight: '4px' }}>esc</KeyboardKeyHint>
-                  <span style={{ paddingBottom: '2px' }}>to cancel</span>
-                </CancelHint>
-              ) : (
+    <>
+      <Toolbar
+        // overflow x is needed because the toolbar is too wide on mobile
+        // overflow x automatically sets overflow y which hides the
+        // category menu
+        css={toolbarScrollCss}
+      >
+        {hasRole(userRoles, WRITE_OBJECTS_ROLES) && (
+          <AnnotationControls>
+            {/* Repeat last action */}
+            {!isSmallScreen && (
+              <>
                 <Tooltip>
-                  <TooltipTrigger asChild disabled={isSmallScreen || image.awaitingPrediction}>
-                    <ToolbarIconButton onClick={handleAddObjectButtonClick}>
-                      <GroupIcon />
+                  <TooltipTrigger asChild>
+                    <ToolbarIconButton onClick={handleRepeatAction} disabled={!lastAction}>
+                      <ReloadIcon />
                     </ToolbarIconButton>
                   </TooltipTrigger>
                   <TooltipContent side="top" sideOffset={5}>
-                    Add object
+                    Repeat last action
                     <TooltipArrow />
                   </TooltipContent>
                 </Tooltip>
-              )}
-              <Separator />
-            </>
-          )}
 
-          {/* Comments */}
-          {isSmallScreen ? (
-            <ToolbarIconButton
-              disabled={
-                !hasRole(userRoles, READ_COMMENTS_ROLES) ||
-                !hasRole(userRoles, WRITE_COMMENTS_ROLES)
-              }
-              css={{ position: 'relative' }}
-              onClick={() => dispatch(setMobileCommentFocusIndex(image._id))}
-            >
-              <ChatBubbleIcon />
-              {image.comments?.length > 0 && <Badge>{image.comments?.length}</Badge>}
-            </ToolbarIconButton>
-          ) : (
-            <CommentsPopover image={image} userRoles={userRoles} />
-          )}
+                <Separator />
+              </>
+            )}
 
-          <Separator />
+            {/* Edit */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {!isSmallScreen && catSelectorOpen ? (
+                  <CategorySelector handleCategoryChange={handleCategoryChange} />
+                ) : (
+                  <ToolbarIconButton
+                    onClick={handleEditAllLabelsButtonClick}
+                    disabled={allObjectsLocked || image.awaitingPrediction}
+                  >
+                    <Pencil1Icon />
+                  </ToolbarIconButton>
+                )}
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={5}>
+                Edit all labels
+                <TooltipArrow />
+              </TooltipContent>
+            </Tooltip>
 
-          {/* Unlock */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <ToolbarIconButton
-                onClick={handleUnlockAllButtonClick}
-                disabled={allObjectsUnlocked || !hasRenderedObjects || image.awaitingPrediction}
-              >
-                <LockOpen1Icon />
-              </ToolbarIconButton>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={5}>
-              Unlock all objects
-              <TooltipArrow />
-            </TooltipContent>
-          </Tooltip>
+            <Separator />
 
-          {/* On mobile, include the share button as well */}
-          {isSmallScreen && (
-            <>
-              <Separator />
-              <ShareImageButton imageId={image._id} />
-            </>
-          )}
-        </AnnotationControls>
-      )}
+            {/* Validate/invalidate */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToolbarIconButton
+                  onClick={(e) => handleValidateAllButtonClick(e, true)}
+                  disabled={allObjectsLocked || image.awaitingPrediction}
+                >
+                  <CheckIcon />
+                </ToolbarIconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={5}>
+                Validate all labels
+                <TooltipArrow />
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToolbarIconButton
+                  onClick={(e) => handleValidateAllButtonClick(e, false)}
+                  disabled={allObjectsLocked || image.awaitingPrediction}
+                >
+                  <Cross2Icon />
+                </ToolbarIconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={5}>
+                Invalidate all labels
+                <TooltipArrow />
+              </TooltipContent>
+            </Tooltip>
 
-      {/* Increment/Decrement */}
-      {handleIncrementClick !== undefined && (
-        <IncrementControls>
-          <Tooltip>
-            <TooltipTrigger asChild>
+            <Separator />
+
+            {/* Mark empty */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToolbarIconButton
+                  onClick={handleMarkEmptyButtonClick}
+                  disabled={image.awaitingPrediction}
+                >
+                  <ValueNoneIcon />
+                </ToolbarIconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={5}>
+                Mark empty
+                <TooltipArrow />
+              </TooltipContent>
+            </Tooltip>
+
+            <Separator />
+
+            {/* Add object */}
+            {!isSmallScreen && (
+              <>
+                {isDrawingBbox ? (
+                  <CancelHint>
+                    <KeyboardKeyHint css={{ marginRight: '4px' }}>esc</KeyboardKeyHint>
+                    <span style={{ paddingBottom: '2px' }}>to cancel</span>
+                  </CancelHint>
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild disabled={isSmallScreen || image.awaitingPrediction}>
+                      <ToolbarIconButton onClick={handleAddObjectButtonClick}>
+                        <GroupIcon />
+                      </ToolbarIconButton>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" sideOffset={5}>
+                      Add object
+                      <TooltipArrow />
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+                <Separator />
+              </>
+            )}
+
+            {/* Unlock */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToolbarIconButton
+                  onClick={handleUnlockAllButtonClick}
+                  disabled={allObjectsUnlocked || !hasRenderedObjects || image.awaitingPrediction}
+                >
+                  <LockOpen1Icon />
+                </ToolbarIconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={5}>
+                Unlock all objects
+                <TooltipArrow />
+              </TooltipContent>
+            </Tooltip>
+
+            <Separator />
+
+            {/* Comments / Small screen menu */}
+            {isSmallScreen ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <ToolbarIconButton css={{ position: 'relative' }}>
+                    <DotsHorizontalIcon />
+                  </ToolbarIconButton>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent sideOffset={5}>
+                  <DropdownMenuItem
+                    disabled={
+                      !hasRole(userRoles, READ_COMMENTS_ROLES) ||
+                      !hasRole(userRoles, WRITE_COMMENTS_ROLES)
+                    }
+                    onSelect={() => dispatch(setMobileCommentFocusIndex(image._id))}
+                  >
+                    <DropdownMenuItemIconLeft>
+                      <ChatBubbleIcon />
+                    </DropdownMenuItemIconLeft>
+                    Comments{image.comments?.length > 0 && <Badge>{image.comments?.length}</Badge>}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={handleCopyUrl}>
+                    <DropdownMenuItemIconLeft>
+                      <ClipboardCopyIcon />
+                    </DropdownMenuItemIconLeft>
+                    Copy image URL
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <CommentsPopover image={image} userRoles={userRoles} />
+            )}
+          </AnnotationControls>
+        )}
+
+        {/* Increment/Decrement */}
+        {handleIncrementClick !== undefined && (
+          <IncrementControls>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <IconButton
+                    variant="ghost"
+                    size="med"
+                    onClick={() => handleIncrementClick('decrement')}
+                  >
+                    <ChevronLeftIcon />
+                  </IconButton>
+                  <IconButton
+                    variant="ghost"
+                    size="med"
+                    onClick={() => handleIncrementClick('increment')}
+                  >
+                    <ChevronRightIcon />
+                  </IconButton>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={5}>
+                Hint: you can use the <KeyboardKeyHint>WASD</KeyboardKeyHint> or{' '}
+                <KeyboardKeyHint>arrow</KeyboardKeyHint> keys to navigate images
+                <TooltipArrow />
+              </TooltipContent>
+            </Tooltip>
+          </IncrementControls>
+        )}
+      </Toolbar>
+
+      {/* Copy image URL toast (mobile overflow menu feedback) */}
+      {showCopyToast && (
+        <>
+          <Toast open={showCopyToast} duration={2000} onOpenChange={() => setShowCopyToast(false)}>
+            <ToastTitle variant="green" css={{ marginBottom: 0 }}>
+              URL copied to clipboard
+            </ToastTitle>
+            <ToastDescription asChild>
               <div>
-                <IconButton
-                  variant="ghost"
-                  size="med"
-                  onClick={() => handleIncrementClick('decrement')}
-                >
-                  <ChevronLeftIcon />
-                </IconButton>
-                <IconButton
-                  variant="ghost"
-                  size="med"
-                  onClick={() => handleIncrementClick('increment')}
-                >
-                  <ChevronRightIcon />
-                </IconButton>
+                {truncateString(
+                  `${window.location.origin}/app/${selectedProject?._id}/${selectedProject?.views?.find((v) => v.name === 'All images')?._id}?img=${image._id}`,
+                  40,
+                )}
               </div>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={5}>
-              Hint: you can use the <KeyboardKeyHint>WASD</KeyboardKeyHint> or{' '}
-              <KeyboardKeyHint>arrow</KeyboardKeyHint> keys to navigate images
-              <TooltipArrow />
-            </TooltipContent>
-          </Tooltip>
-        </IncrementControls>
+            </ToastDescription>
+            <ToastAction asChild altText="Dismiss">
+              <IconButton variant="ghost">
+                <Cross2Icon />
+              </IconButton>
+            </ToastAction>
+          </Toast>
+          <ToastViewport />
+        </>
       )}
-    </Toolbar>
+    </>
   );
 };
 

--- a/src/features/loupe/ImageReviewToolbar.jsx
+++ b/src/features/loupe/ImageReviewToolbar.jsx
@@ -161,7 +161,7 @@ const ImageReviewToolbar = ({
   handleUnlockAllButtonClick,
   handleIncrementClick,
   bboxesVisible = true,
-  toggleBboxesVisible,
+  toggleBboxesVisible = () => {},
 }) => {
   const userRoles = useSelector(selectUserCurrentRoles);
   const userId = useSelector(selectUserUsername);

--- a/src/features/loupe/ImageReviewToolbar.jsx
+++ b/src/features/loupe/ImageReviewToolbar.jsx
@@ -417,7 +417,7 @@ const ImageReviewToolbar = ({
                       <DotsHorizontalIcon />
                     </ToolbarIconButton>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent sideOffset={5}>
+                  <DropdownMenuContent side="top" sideOffset={5}>
                     <DropdownMenuItem
                       disabled={
                         !hasRole(userRoles, READ_COMMENTS_ROLES) ||

--- a/src/features/loupe/ImageReviewToolbar.jsx
+++ b/src/features/loupe/ImageReviewToolbar.jsx
@@ -14,6 +14,8 @@ import {
   ChatBubbleIcon,
   DotsHorizontalIcon,
   ClipboardCopyIcon,
+  EyeOpenIcon,
+  EyeClosedIcon,
 } from '@radix-ui/react-icons';
 import IconButton from '../../components/IconButton.jsx';
 import {
@@ -121,13 +123,18 @@ export const ToolbarIconButton = styled(Button, {
     color: violet.violet11,
   },
   svg: {
-    marginRight: '$1',
-    marginLeft: '$1',
+    marginRight: '$1 !important',
+    marginLeft: '$1 !important',
   },
 });
 
 const AnnotationControls = styled('div', {
   display: 'flex',
+});
+
+const LeftGroup = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
 });
 
 const IncrementControls = styled('div', {
@@ -153,6 +160,8 @@ const ImageReviewToolbar = ({
   handleAddObjectButtonClick,
   handleUnlockAllButtonClick,
   handleIncrementClick,
+  bboxesVisible = true,
+  toggleBboxesVisible,
 }) => {
   const userRoles = useSelector(selectUserCurrentRoles);
   const userId = useSelector(selectUserUsername);
@@ -229,178 +238,215 @@ const ImageReviewToolbar = ({
         // category menu
         css={toolbarScrollCss}
       >
-        {hasRole(userRoles, WRITE_OBJECTS_ROLES) && (
-          <AnnotationControls>
-            {/* Repeat last action */}
-            {!isSmallScreen && (
-              <>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <ToolbarIconButton onClick={handleRepeatAction} disabled={!lastAction}>
-                      <ReloadIcon />
-                    </ToolbarIconButton>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={5}>
-                    Repeat last action
-                    <TooltipArrow />
-                  </TooltipContent>
-                </Tooltip>
-
-                <Separator />
-              </>
-            )}
-
-            {/* Edit */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {!isSmallScreen && catSelectorOpen ? (
-                  <CategorySelector handleCategoryChange={handleCategoryChange} />
-                ) : (
-                  <ToolbarIconButton
-                    onClick={handleEditAllLabelsButtonClick}
-                    disabled={allObjectsLocked || image.awaitingPrediction}
-                  >
-                    <Pencil1Icon />
-                  </ToolbarIconButton>
-                )}
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={5}>
-                Edit all labels
-                <TooltipArrow />
-              </TooltipContent>
-            </Tooltip>
-
-            <Separator />
-
-            {/* Validate/invalidate */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <ToolbarIconButton
-                  onClick={(e) => handleValidateAllButtonClick(e, true)}
-                  disabled={allObjectsLocked || image.awaitingPrediction}
-                >
-                  <CheckIcon />
-                </ToolbarIconButton>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={5}>
-                Validate all labels
-                <TooltipArrow />
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <ToolbarIconButton
-                  onClick={(e) => handleValidateAllButtonClick(e, false)}
-                  disabled={allObjectsLocked || image.awaitingPrediction}
-                >
-                  <Cross2Icon />
-                </ToolbarIconButton>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={5}>
-                Invalidate all labels
-                <TooltipArrow />
-              </TooltipContent>
-            </Tooltip>
-
-            <Separator />
-
-            {/* Mark empty */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <ToolbarIconButton
-                  onClick={handleMarkEmptyButtonClick}
-                  disabled={image.awaitingPrediction}
-                >
-                  <ValueNoneIcon />
-                </ToolbarIconButton>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={5}>
-                Mark empty
-                <TooltipArrow />
-              </TooltipContent>
-            </Tooltip>
-
-            <Separator />
-
-            {/* Add object */}
-            {!isSmallScreen && (
-              <>
-                {isDrawingBbox ? (
-                  <CancelHint>
-                    <KeyboardKeyHint css={{ marginRight: '4px' }}>esc</KeyboardKeyHint>
-                    <span style={{ paddingBottom: '2px' }}>to cancel</span>
-                  </CancelHint>
-                ) : (
+        <LeftGroup>
+          {hasRole(userRoles, WRITE_OBJECTS_ROLES) && (
+            <AnnotationControls>
+              {/* Repeat last action */}
+              {!isSmallScreen && (
+                <>
                   <Tooltip>
-                    <TooltipTrigger asChild disabled={isSmallScreen || image.awaitingPrediction}>
-                      <ToolbarIconButton onClick={handleAddObjectButtonClick}>
-                        <GroupIcon />
+                    <TooltipTrigger asChild>
+                      <ToolbarIconButton
+                        onClick={handleRepeatAction}
+                        disabled={!lastAction || !bboxesVisible}
+                      >
+                        <ReloadIcon />
                       </ToolbarIconButton>
                     </TooltipTrigger>
                     <TooltipContent side="top" sideOffset={5}>
-                      Add object
+                      Repeat last action
                       <TooltipArrow />
                     </TooltipContent>
                   </Tooltip>
-                )}
-                <Separator />
-              </>
-            )}
 
-            {/* Unlock */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <ToolbarIconButton
-                  onClick={handleUnlockAllButtonClick}
-                  disabled={allObjectsUnlocked || !hasRenderedObjects || image.awaitingPrediction}
-                >
-                  <LockOpen1Icon />
-                </ToolbarIconButton>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={5}>
-                Unlock all objects
-                <TooltipArrow />
-              </TooltipContent>
-            </Tooltip>
+                  <Separator />
+                </>
+              )}
 
-            <Separator />
+              {/* Edit all Labels */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {!isSmallScreen && catSelectorOpen && bboxesVisible ? (
+                    <CategorySelector handleCategoryChange={handleCategoryChange} />
+                  ) : (
+                    <ToolbarIconButton
+                      onClick={handleEditAllLabelsButtonClick}
+                      disabled={allObjectsLocked || image.awaitingPrediction || !bboxesVisible}
+                    >
+                      <Pencil1Icon />
+                    </ToolbarIconButton>
+                  )}
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={5}>
+                  Edit all labels
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip>
 
-            {/* Comments / Small screen menu */}
-            {isSmallScreen ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <ToolbarIconButton css={{ position: 'relative' }}>
-                    <DotsHorizontalIcon />
-                  </ToolbarIconButton>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent sideOffset={5}>
-                  <DropdownMenuItem
-                    disabled={
-                      !hasRole(userRoles, READ_COMMENTS_ROLES) ||
-                      !hasRole(userRoles, WRITE_COMMENTS_ROLES)
-                    }
-                    onSelect={() => dispatch(setMobileCommentFocusIndex(image._id))}
+              <Separator />
+
+              {/* Validate/invalidate all Labels */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToolbarIconButton
+                    onClick={(e) => handleValidateAllButtonClick(e, true)}
+                    disabled={allObjectsLocked || image.awaitingPrediction || !bboxesVisible}
                   >
-                    <DropdownMenuItemIconLeft>
-                      <ChatBubbleIcon />
-                    </DropdownMenuItemIconLeft>
-                    Comments{image.comments?.length > 0 && <Badge>{image.comments?.length}</Badge>}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={handleCopyUrl}>
-                    <DropdownMenuItemIconLeft>
-                      <ClipboardCopyIcon />
-                    </DropdownMenuItemIconLeft>
-                    Copy image URL
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <CommentsPopover image={image} userRoles={userRoles} />
-            )}
-          </AnnotationControls>
-        )}
+                    <CheckIcon />
+                  </ToolbarIconButton>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={5}>
+                  Validate all labels
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToolbarIconButton
+                    onClick={(e) => handleValidateAllButtonClick(e, false)}
+                    disabled={allObjectsLocked || image.awaitingPrediction || !bboxesVisible}
+                  >
+                    <Cross2Icon />
+                  </ToolbarIconButton>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={5}>
+                  Invalidate all labels
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip>
 
-        {/* Increment/Decrement */}
+              <Separator />
+
+              {/* Add empty object */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToolbarIconButton
+                    onClick={handleMarkEmptyButtonClick}
+                    disabled={image.awaitingPrediction || !bboxesVisible}
+                  >
+                    <ValueNoneIcon />
+                  </ToolbarIconButton>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={5}>
+                  Mark empty
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip>
+
+              <Separator />
+
+              {/* Add object */}
+              {!isSmallScreen && (
+                <>
+                  {isDrawingBbox ? (
+                    <CancelHint>
+                      <KeyboardKeyHint css={{ marginRight: '4px' }}>esc</KeyboardKeyHint>
+                      <span style={{ paddingBottom: '2px' }}>to cancel</span>
+                    </CancelHint>
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger
+                        asChild
+                        disabled={isSmallScreen || image.awaitingPrediction || !bboxesVisible}
+                      >
+                        <ToolbarIconButton
+                          onClick={handleAddObjectButtonClick}
+                          disabled={!bboxesVisible}
+                        >
+                          <GroupIcon />
+                        </ToolbarIconButton>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" sideOffset={5}>
+                        Add object
+                        <TooltipArrow />
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  <Separator />
+                </>
+              )}
+
+              {/* Unlock */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToolbarIconButton
+                    onClick={handleUnlockAllButtonClick}
+                    disabled={
+                      allObjectsUnlocked ||
+                      !hasRenderedObjects ||
+                      image.awaitingPrediction ||
+                      !bboxesVisible
+                    }
+                  >
+                    <LockOpen1Icon />
+                  </ToolbarIconButton>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={5}>
+                  Unlock all objects
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip>
+
+              <Separator />
+
+              {/* Toggle bbox visibility */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <ToolbarIconButton
+                    onClick={toggleBboxesVisible}
+                    data-state={bboxesVisible ? undefined : 'on'}
+                  >
+                    {bboxesVisible ? <EyeOpenIcon /> : <EyeClosedIcon />}
+                  </ToolbarIconButton>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={5}>
+                  {bboxesVisible
+                    ? 'Temporarily hide bounding boxes'
+                    : 'Temporarily show bounding boxes'}
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip>
+
+              <Separator />
+
+              {/* Comments / Small screen menu */}
+              {isSmallScreen ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <ToolbarIconButton css={{ position: 'relative' }}>
+                      <DotsHorizontalIcon />
+                    </ToolbarIconButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent sideOffset={5}>
+                    <DropdownMenuItem
+                      disabled={
+                        !hasRole(userRoles, READ_COMMENTS_ROLES) ||
+                        !hasRole(userRoles, WRITE_COMMENTS_ROLES)
+                      }
+                      onSelect={() => dispatch(setMobileCommentFocusIndex(image._id))}
+                    >
+                      <DropdownMenuItemIconLeft>
+                        <ChatBubbleIcon />
+                      </DropdownMenuItemIconLeft>
+                      Comments
+                      {image.comments?.length > 0 && <Badge>{image.comments?.length}</Badge>}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={handleCopyUrl}>
+                      <DropdownMenuItemIconLeft>
+                        <ClipboardCopyIcon />
+                      </DropdownMenuItemIconLeft>
+                      Copy image URL
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : (
+                <CommentsPopover image={image} userRoles={userRoles} />
+              )}
+            </AnnotationControls>
+          )}
+        </LeftGroup>
+
+        {/* Increment/Decrement image */}
         {handleIncrementClick !== undefined && (
           <IncrementControls>
             <Tooltip>

--- a/src/features/loupe/Loupe.jsx
+++ b/src/features/loupe/Loupe.jsx
@@ -14,7 +14,7 @@ import {
   incrementImage,
 } from '../review/reviewSlice.js';
 import { selectProjectTags } from '../projects/projectsSlice.js';
-import { toggleOpenLoupe, drawBboxStart, addLabelStart } from './loupeSlice.js';
+import { toggleOpenLoupe, drawBboxStart, drawBboxEnd, addLabelStart } from './loupeSlice.js';
 import { selectUserUsername, selectUserCurrentRoles } from '../auth/authSlice';
 import { hasRole, WRITE_OBJECTS_ROLES } from '../auth/roles.js';
 import PanelHeader from '../../components/PanelHeader.jsx';
@@ -24,6 +24,15 @@ import ShareImageButton from './ShareImageButton';
 import { ImageTagsToolbar } from './ImageTagsToolbar.jsx';
 import { ImageMetadata } from './ImageMetadata.jsx';
 import LoupeDropdown from './LoupeDropdown.jsx';
+import {
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastAction,
+  ToastViewport,
+} from '../../components/Toast.jsx';
+import IconButton from '../../components/IconButton.jsx';
+import { Cross2Icon } from '@radix-ui/react-icons';
 
 const ImagePane = styled('div', {
   // display: 'flex',
@@ -178,6 +187,14 @@ const Loupe = () => {
   }, [image?._id]);
   const toggleBboxesVisible = useCallback(() => setBboxesVisible((v) => !v), []);
 
+  // when bboxes are hidden, cancel any in-progress bbox drawing so the toolbar
+  // doesn't get stuck showing the "esc to cancel" hint with no visible overlay
+  useEffect(() => {
+    if (!bboxesVisible) dispatch(drawBboxEnd());
+  }, [bboxesVisible, dispatch]);
+
+  const [showHotkeyBlockedToast, setShowHotkeyBlockedToast] = useState(false);
+
   // Listen for hotkeys
   // TODO: should this all live in the ImageReviewToolbar?
   // TODO: use react synthetic onKeyDown events instead?
@@ -199,23 +216,40 @@ const Loupe = () => {
 
       if (delta) {
         dispatch(incrementImage(delta));
+        return;
       }
 
       // ctrl-z/shift-ctrl-z (undo/redo)
       if ((e.ctrlKey || e.metaKey) && e.shiftKey && charCode === 'z') {
+        if (!bboxesVisible) {
+          setShowHotkeyBlockedToast(true);
+          return;
+        }
         dispatch(undoActions.redo());
       } else if ((e.ctrlKey || e.metaKey) && charCode === 'z') {
+        if (!bboxesVisible) {
+          setShowHotkeyBlockedToast(true);
+          return;
+        }
         dispatch(undoActions.undo());
       }
 
       // ctrl-e (edit all)
       if ((e.ctrlKey || e.metaKey) && charCode === 'e' && hasRole(userRoles, WRITE_OBJECTS_ROLES)) {
+        if (!bboxesVisible) {
+          setShowHotkeyBlockedToast(true);
+          return;
+        }
         dispatch(addLabelStart('from-review-toolbar'));
       }
 
       // ctrl-v (repeat last action)
       if ((e.ctrlKey || e.metaKey) && charCode === 'v' && hasRole(userRoles, WRITE_OBJECTS_ROLES)) {
         e.stopPropagation();
+        if (!bboxesVisible) {
+          setShowHotkeyBlockedToast(true);
+          return;
+        }
         handleRepeatAction();
       }
 
@@ -225,7 +259,7 @@ const Loupe = () => {
       //   dispatch(drawBboxStart());
       // }
     },
-    [dispatch, image],
+    [dispatch, image, bboxesVisible, userRoles, handleRepeatAction],
   );
 
   useEffect(() => {
@@ -284,6 +318,28 @@ const Loupe = () => {
           <ShareImageButton imageId={image?._id} />
         </ShareImage>
       </ToolbarContainer>
+      {showHotkeyBlockedToast && (
+        <>
+          <Toast
+            open={showHotkeyBlockedToast}
+            duration={3000}
+            onOpenChange={() => setShowHotkeyBlockedToast(false)}
+          >
+            <ToastTitle variant="red" css={{ marginBottom: 0 }}>
+              Hotkeys disabled
+            </ToastTitle>
+            <ToastDescription asChild>
+              <div>All bounding boxes must be visible to use keyboard shortcuts.</div>
+            </ToastDescription>
+            <ToastAction asChild altText="Dismiss">
+              <IconButton variant="ghost">
+                <Cross2Icon />
+              </IconButton>
+            </ToastAction>
+          </Toast>
+          <ToastViewport />
+        </>
+      )}
     </StyledLoupe>
   );
 };

--- a/src/features/loupe/Loupe.jsx
+++ b/src/features/loupe/Loupe.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { actions as undoActions } from 'redux-undo-redo';
 import { styled } from '../../theme/stitches.config.js';
@@ -172,6 +172,12 @@ const Loupe = () => {
     dispatch(incrementImage(delta));
   };
 
+  const [bboxesVisible, setBboxesVisible] = useState(true);
+  useEffect(() => {
+    setBboxesVisible(true);
+  }, [image?._id]);
+  const toggleBboxesVisible = useCallback(() => setBboxesVisible((v) => !v), []);
+
   // Listen for hotkeys
   // TODO: should this all live in the ImageReviewToolbar?
   // TODO: use react synthetic onKeyDown events instead?
@@ -247,6 +253,7 @@ const Loupe = () => {
               workingImages={workingImages}
               image={image}
               focusIndex={focusIndex}
+              bboxesVisible={bboxesVisible}
               handleMarkEmptyButtonClick={markEmpty}
               handleAddObjectButtonClick={handleAddObjectButtonClick}
               css={{ height: '100%', width: '100%', objectFit: 'contain' }}
@@ -267,6 +274,8 @@ const Loupe = () => {
               handleAddObjectButtonClick={handleAddObjectButtonClick}
               handleUnlockAllButtonClick={handleUnlockAllButtonClick}
               handleIncrementClick={handleIncrementClick}
+              bboxesVisible={bboxesVisible}
+              toggleBboxesVisible={toggleBboxesVisible}
             />
             <ImageTagsToolbar image={image} projectTags={projectTags} />
           </>

--- a/src/features/loupe/SmallScreensLoupe.jsx
+++ b/src/features/loupe/SmallScreensLoupe.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { styled } from '../../theme/stitches.config';
 import FullSizeImage from './FullSizeImage';
 import ImageReviewToolbar from './ImageReviewToolbar';
@@ -118,6 +118,12 @@ export const SmallScreensLoupe = ({ image, idx, workingImages, shouldShowToolbar
     dispatch(objectsManuallyUnlocked({ objects }));
   };
 
+  const [bboxesVisible, setBboxesVisible] = useState(true);
+  useEffect(() => {
+    setBboxesVisible(true);
+  }, [image?._id]);
+  const toggleBboxesVisible = useCallback(() => setBboxesVisible((v) => !v), []);
+
   return (
     <FullSizeImageWrapper style={style}>
       <ImageContainer>
@@ -126,6 +132,7 @@ export const SmallScreensLoupe = ({ image, idx, workingImages, shouldShowToolbar
           workingImages={workingImages}
           image={image}
           focusIndex={{ image: idx }}
+          bboxesVisible={bboxesVisible}
           css={{
             height: '100%',
             width: '100%',
@@ -143,6 +150,8 @@ export const SmallScreensLoupe = ({ image, idx, workingImages, shouldShowToolbar
             handleValidateAllButtonClick={handleValidateAllButtonClick}
             handleMarkEmptyButtonClick={markEmpty}
             handleUnlockAllButtonClick={handleUnlockAllButtonClick}
+            bboxesVisible={bboxesVisible}
+            toggleBboxesVisible={toggleBboxesVisible}
           />
           <ImageTagsToolbar image={image} projectTags={projectTags} />
         </ToolbarContainer>

--- a/src/features/loupe/SmallScreensLoupe.jsx
+++ b/src/features/loupe/SmallScreensLoupe.jsx
@@ -15,6 +15,7 @@ import {
   objectsManuallyUnlocked,
 } from '../review/reviewSlice.js';
 import { selectProjectTags } from '../projects/projectsSlice.js';
+import { drawBboxEnd } from './loupeSlice.js';
 
 const ImageContainer = styled('div', {
   backgroundColor: '$backgroundBlack',
@@ -123,6 +124,11 @@ export const SmallScreensLoupe = ({ image, idx, workingImages, shouldShowToolbar
     setBboxesVisible(true);
   }, [image?._id]);
   const toggleBboxesVisible = useCallback(() => setBboxesVisible((v) => !v), []);
+
+  // when bboxes are hidden, cancel any in-progress bbox drawing
+  useEffect(() => {
+    if (!bboxesVisible) dispatch(drawBboxEnd());
+  }, [bboxesVisible, dispatch]);
 
   return (
     <FullSizeImageWrapper style={style}>


### PR DESCRIPTION
Adds button in `ImageReviewToolbar` to temporarily hide/show bounding boxes to make it easier to see the image underneath. 

This PR also adds a dropdown menu to the `ImageReviewToolbar` on small screens to conserve horizontal space. For starters the "Copy image URL" button and "Comments" buttons have been moved into the menu to make room for the bounding box visibility toggle.

NOTE: when the bounding box visibility is turned off we the other buttons in the `ImageReviewToolbar` and hotkeys so that users can't modify the Objects or Labels while they aren't visible. However, it's still possible to perform CRUD ops on Objects and Labels by opening the context menu on the image table rows (i.e., by right-clicking after selecting an image or multiple images from the images table). If we wanted to disable the context menu if the `!bboxesVisible`, we'd probably need to lift it up into Redux state. 

Closes: https://github.com/tnc-ca-geo/animl-frontend/issues/450