### PR TITLE
Project fetching and navigation refactor

### DIFF
--- a/src/api/buildQuery.js
+++ b/src/api/buildQuery.js
@@ -210,16 +210,42 @@ const projectAutomationRuleFields = `
   }
 `;
 
+// Lightweight representation of a Project, used to populate the Project & View
+// nav menus for every Project a user has access to. Full Project detail is only
+// ever fetched for the currently selected Project (see getProject below).
+const projectStubFields = `
+  _id
+  name
+  description
+  views {
+    _id
+    name
+  }
+`;
+
 const queries = {
-  getProjects: (input) => ({
+  // fetch lightweight stubs for every Project the user has access to
+  getProjectStubs: () => ({
     template: `
-      query GetProjects($input: QueryProjectsInput) {
+      query GetProjectStubs {
+        projects {
+          ${projectStubFields}
+        }
+      }
+    `,
+    variables: {},
+  }),
+
+  // fetch full detail for a single Project
+  getProject: (projId) => ({
+    template: `
+      query GetProject($input: QueryProjectsInput) {
         projects(input: $input) {
           ${projectFields}
         }
       }
     `,
-    variables: { input: input },
+    variables: { input: { _ids: [projId] } },
   }),
 
   getProjectAutomationRules: (input) => ({

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -4,10 +4,10 @@ import { routerMiddleware } from 'connected-react-router';
 import createRootReducer from './rootReducer';
 import { preFocusImage } from '../features/images/imagesMiddleware';
 import {
-  enrichProjAndViewPayload,
   setActiveFiltersToSelectedView,
   diffFilters,
 } from '../features/projects/projectsMiddleware';
+import { projectsListener } from '../features/projects/projectsListeners';
 import { focusMiddleware } from '../features/review/focusMiddleware';
 import { labelMiddleware } from '../features/review/labelMiddleware';
 import { objectMiddleware } from '../features/review/objectMiddleware';
@@ -21,8 +21,8 @@ const store = configureStore({
   reducer: createRootReducer(history),
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware()
+      .prepend(projectsListener.middleware)
       .concat(routerMiddleware(history))
-      .concat(enrichProjAndViewPayload)
       .concat(preFocusImage)
       .concat(diffFilters)
       .concat(setActiveFiltersToSelectedView)

--- a/src/components/ErrorToast.jsx
+++ b/src/components/ErrorToast.jsx
@@ -12,8 +12,10 @@ import {
   dismissTagsError,
 } from '../features/review/reviewSlice';
 import {
-  selectProjectsErrors,
-  dismissProjectsError,
+  selectProjectStubsErrors,
+  dismissProjectStubsError,
+  selectProjectErrors,
+  dismissProjectError,
   selectViewsErrors,
   dismissViewsError,
   selectModelsErrors,
@@ -79,7 +81,8 @@ const ErrorToast = () => {
   const labelsErrors = useSelector(selectLabelsErrors);
   const tagsErrors = useSelector(selectTagsErrors);
   const commentsErrors = useSelector(selectCommentsErrors);
-  const projectsErrors = useSelector(selectProjectsErrors);
+  const projectStubsErrors = useSelector(selectProjectStubsErrors);
+  const projectErrors = useSelector(selectProjectErrors);
   const viewsErrors = useSelector(selectViewsErrors);
   const depsErrors = useSelector(selectDeploymentsErrors);
   const modelsErrors = useSelector(selectModelsErrors);
@@ -109,7 +112,8 @@ const ErrorToast = () => {
     enrichErrors(tagsErrors, 'Tag Error', 'tags'),
     enrichErrors(projectTagErrors, 'Tag Error', 'projectTags'),
     enrichErrors(commentsErrors, 'Comment Error', 'comments'),
-    enrichErrors(projectsErrors, 'Project Error', 'projects'),
+    enrichErrors(projectStubsErrors, 'Project Error', 'projectStubs'),
+    enrichErrors(projectErrors, 'Project Error', 'project'),
     enrichErrors(viewsErrors, 'View Error', 'views'),
     enrichErrors(depsErrors, 'Deployment Error', 'deployments'),
     enrichErrors(modelsErrors, 'Model Error', 'models'),
@@ -186,7 +190,8 @@ const dismissErrorActions = {
   tags: (i) => dismissTagsError(i),
   projectTags: (i) => dismissProjectTagErrors(i),
   comments: (i) => dismissCommentsError(i),
-  projects: (i) => dismissProjectsError(i),
+  projectStubs: (i) => dismissProjectStubsError(i),
+  project: (i) => dismissProjectError(i),
   createProject: (i) => dismissCreateProjectError(i),
   updateProject: (i) => dismissUpdateProjectError(i),
   views: (i) => dismissViewsError(i),

--- a/src/features/cameras/wirelessCamerasSlice.js
+++ b/src/features/cameras/wirelessCamerasSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { call } from '../../api';
 import { Auth } from 'aws-amplify';
-import { setSelectedProjAndView } from '../projects/projectsSlice';
+import { projectChanged, selectSelectedProjectId } from '../projects/projectsSlice';
 
 const initialState = {
   wirelessCameras: [],
@@ -147,16 +147,14 @@ export const wirelessCamerasSlice = createSlice({
   },
 
   extraReducers: (builder) => {
-    builder.addCase(setSelectedProjAndView, (state, { payload }) => {
-      if (payload.newProjSelected) {
-        state.wirelessCameras = [];
-        state.loadingState = {
-          isLoading: false,
-          operation: null,
-          errors: null,
-          noneFound: null,
-        };
-      }
+    builder.addCase(projectChanged, (state) => {
+      state.wirelessCameras = [];
+      state.loadingState = {
+        isLoading: false,
+        operation: null,
+        errors: null,
+        noneFound: null,
+      };
     });
   },
 });
@@ -193,10 +191,9 @@ export const fetchWirelessCameras = () => async (dispatch, getState) => {
     const currentUser = await Auth.currentAuthenticatedUser();
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
     if (token) {
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
       const res = await call({
-        projId: selectedProj._id,
+        projId,
         request: 'getWirelessCameras',
       });
       dispatch(getWirelessCamerasSuccess(res.wirelessCameras));
@@ -213,12 +210,11 @@ export const registerCamera = (payload, resetFormCallback) => {
       dispatch(registerCameraStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'registerCamera',
           input: payload,
         });
@@ -238,12 +234,11 @@ export const unregisterCamera = (payload) => async (dispatch, getState) => {
     dispatch(unregisterCameraStart());
     const currentUser = await Auth.currentAuthenticatedUser();
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-    const projects = getState().projects.projects;
-    const selectedProj = projects.find((proj) => proj.selected);
+    const projId = selectSelectedProjectId(getState());
 
-    if (token && selectedProj) {
+    if (token && projId) {
       const res = await call({
-        projId: selectedProj._id,
+        projId,
         request: 'unregisterCamera',
         input: payload,
       });
@@ -260,12 +255,11 @@ export const fetchCameraImageCount = (payload) => async (dispatch, getState) => 
     dispatch(cameraImageCountStart(payload));
     const currentUser = await Auth.currentAuthenticatedUser();
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-    const projects = getState().projects.projects;
-    const selectedProj = projects.find((proj) => proj.selected);
+    const projId = selectSelectedProjectId(getState());
 
-    if (token && selectedProj) {
+    if (token && projId) {
       const res = await call({
-        projId: selectedProj._id,
+        projId,
         request: 'getImagesCount',
         input: { filters: { cameras: [payload.cameraId] } },
       });

--- a/src/features/filters/FiltersPanelFooter.jsx
+++ b/src/features/filters/FiltersPanelFooter.jsx
@@ -99,6 +99,7 @@ const FiltersPanelFooter = ({ areActionsDisabled = false }) => {
   const dispatch = useDispatch();
 
   const handleRefreshClick = () => {
+    if (!selectedProjectId) return;
     dispatch(toggleOpenLoupe(false));
     dispatch(fetchProject(selectedProjectId));
   };

--- a/src/features/filters/FiltersPanelFooter.jsx
+++ b/src/features/filters/FiltersPanelFooter.jsx
@@ -6,10 +6,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectImagesCount, selectImagesCountLoading } from '../images/imagesSlice.js';
 import {
   selectModalOpen,
-  selectSelectedProject,
+  selectSelectedProjectId,
   setModalOpen,
   setModalContent,
-  fetchProjects,
+  fetchProject,
 } from '../projects/projectsSlice.js';
 import { toggleOpenLoupe } from '../loupe/loupeSlice.js';
 import { InfoCircledIcon, SymbolIcon } from '@radix-ui/react-icons';
@@ -95,12 +95,12 @@ const FiltersPanelFooter = ({ areActionsDisabled = false }) => {
   imagesCount = imagesCount && imagesCount.toLocaleString('en-US');
   const imagesCountLoading = useSelector(selectImagesCountLoading);
   const modalOpen = useSelector(selectModalOpen);
-  const selectedProj = useSelector(selectSelectedProject);
+  const selectedProjectId = useSelector(selectSelectedProjectId);
   const dispatch = useDispatch();
 
   const handleRefreshClick = () => {
     dispatch(toggleOpenLoupe(false));
-    dispatch(fetchProjects({ _ids: [selectedProj._id] }));
+    dispatch(fetchProject(selectedProjectId));
   };
 
   const handleModalToggle = (content) => {

--- a/src/features/filters/filtersSlice.js
+++ b/src/features/filters/filtersSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { registerCameraSuccess } from '../cameras/wirelessCamerasSlice';
 import {
-  setSelectedProjAndView,
+  getProjectSuccess,
   createProjectLabelSuccess,
   updateProjectLabelSuccess,
   createProjectTagSuccess,
@@ -113,14 +113,14 @@ export const filtersSlice = createSlice({
 
   extraReducers: (builder) => {
     builder
-      .addCase(setSelectedProjAndView, (state, { payload }) => {
+      .addCase(getProjectSuccess, (state, { payload }) => {
         const { cameraConfigs, labels, tags } = payload.project;
         updateAvailDepFilters(state, cameraConfigs);
         updateAvailCamFilters(state, cameraConfigs);
         updateAvailLabelFilters(state, labels);
         updateAvailTagFilters(state, tags);
-        // set all filters to new selected view? We're currently handling this
-        // by dispatching setActiveFilters from setSelectedProjAndViewMiddleware
+        // active filters are set separately, by the setActiveFiltersToSelectedView
+        // middleware, once a view has been selected
       })
       .addCase(createProjectLabelSuccess, (state, { payload }) => {
         updateAvailLabelFilters(state, payload.labels);

--- a/src/features/images/ImagesGrid.jsx
+++ b/src/features/images/ImagesGrid.jsx
@@ -9,7 +9,7 @@ import { selectFocusChangeType, selectFocusIndex } from '../review/reviewSlice.j
 import { useEffectAfterMount } from '../../app/utils.js';
 import { sortBy } from 'lodash';
 import { selectImagesLoading, sortChanged } from './imagesSlice.js';
-import { selectProjectsLoading } from '../projects/projectsSlice.js';
+import { selectProjectLoading } from '../projects/projectsSlice.js';
 import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner.jsx';
 import { RatsNoneFound } from './RatsNoneFound.jsx';
 import { FloatingToolbar } from './FloatingToolbar.jsx';
@@ -41,7 +41,7 @@ const GridImage = ({ uniqueId, imgUrl, onClickImage, style }) => {
 export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
   const dispatch = useDispatch();
   const focusIndex = useSelector(selectFocusIndex);
-  const projectsLoading = useSelector(selectProjectsLoading);
+  const projectsLoading = useSelector(selectProjectLoading);
   const imagesLoading = useSelector(selectImagesLoading);
   const userRoles = useSelector(selectUserCurrentRoles);
 

--- a/src/features/images/ImagesGrid.jsx
+++ b/src/features/images/ImagesGrid.jsx
@@ -9,7 +9,7 @@ import { selectFocusChangeType, selectFocusIndex } from '../review/reviewSlice.j
 import { useEffectAfterMount } from '../../app/utils.js';
 import { sortBy } from 'lodash';
 import { selectImagesLoading, sortChanged } from './imagesSlice.js';
-import { selectProjectLoading } from '../projects/projectsSlice.js';
+import { selectAnyProjectLoading } from '../projects/projectsSlice.js';
 import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner.jsx';
 import { RatsNoneFound } from './RatsNoneFound.jsx';
 import { FloatingToolbar } from './FloatingToolbar.jsx';
@@ -41,7 +41,7 @@ const GridImage = ({ uniqueId, imgUrl, onClickImage, style }) => {
 export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
   const dispatch = useDispatch();
   const focusIndex = useSelector(selectFocusIndex);
-  const projectsLoading = useSelector(selectProjectLoading);
+  const projectsLoading = useSelector(selectAnyProjectLoading);
   const imagesLoading = useSelector(selectImagesLoading);
   const userRoles = useSelector(selectUserCurrentRoles);
 
@@ -228,7 +228,7 @@ export const ImagesGrid = ({ workingImages, hasNext, loadNextPage }) => {
 
   return (
     <>
-      {(projectsLoading.isLoading || imagesLoading.isLoading) && (
+      {(projectsLoading || imagesLoading.isLoading) && (
         <SpinnerOverlay>
           <SimpleSpinner />
         </SpinnerOverlay>

--- a/src/features/images/ImagesTable.jsx
+++ b/src/features/images/ImagesTable.jsx
@@ -26,7 +26,7 @@ import { selectLoupeOpen } from '../loupe/loupeSlice';
 import { Image } from '../../components/Image';
 import LabelPills from './LabelPills';
 import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner';
-import { selectProjectLoading } from '../projects/projectsSlice';
+import { selectAnyProjectLoading } from '../projects/projectsSlice';
 import DeleteImagesAlert from './DeleteImagesAlert.jsx';
 import { columnConfig, columnsToHideMap, defaultColumnDims, tableBreakpoints } from './config';
 import { RatsNoneFound } from './RatsNoneFound.jsx';
@@ -171,7 +171,7 @@ const ReviewedIcon = ({ reviewed }) => (
 
 const ImagesTable = ({ workingImages, hasNext, loadNextPage }) => {
   const dispatch = useDispatch();
-  const projectsLoading = useSelector(selectProjectLoading);
+  const projectsLoading = useSelector(selectAnyProjectLoading);
   const imagesLoading = useSelector(selectImagesLoading);
   const isLoupeOpen = useSelector(selectLoupeOpen);
   const focusIndex = useSelector(selectFocusIndex);
@@ -313,7 +313,7 @@ const ImagesTable = ({ workingImages, hasNext, loadNextPage }) => {
 
   return (
     <TableContainer ref={ref}>
-      {(projectsLoading.isLoading || imagesLoading.isLoading) && (
+      {(projectsLoading || imagesLoading.isLoading) && (
         <SpinnerOverlay>
           <SimpleSpinner />
         </SpinnerOverlay>

--- a/src/features/images/ImagesTable.jsx
+++ b/src/features/images/ImagesTable.jsx
@@ -26,7 +26,7 @@ import { selectLoupeOpen } from '../loupe/loupeSlice';
 import { Image } from '../../components/Image';
 import LabelPills from './LabelPills';
 import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner';
-import { selectProjectsLoading } from '../projects/projectsSlice';
+import { selectProjectLoading } from '../projects/projectsSlice';
 import DeleteImagesAlert from './DeleteImagesAlert.jsx';
 import { columnConfig, columnsToHideMap, defaultColumnDims, tableBreakpoints } from './config';
 import { RatsNoneFound } from './RatsNoneFound.jsx';
@@ -171,7 +171,7 @@ const ReviewedIcon = ({ reviewed }) => (
 
 const ImagesTable = ({ workingImages, hasNext, loadNextPage }) => {
   const dispatch = useDispatch();
-  const projectsLoading = useSelector(selectProjectsLoading);
+  const projectsLoading = useSelector(selectProjectLoading);
   const imagesLoading = useSelector(selectImagesLoading);
   const isLoupeOpen = useSelector(selectLoupeOpen);
   const focusIndex = useSelector(selectFocusIndex);

--- a/src/features/images/imagesSlice.js
+++ b/src/features/images/imagesSlice.js
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 import { call } from '../../api';
 import { enrichImages } from './utils';
 import { setActiveFilters } from '../filters/filtersSlice';
+import { selectSelectedProject, selectSelectedProjectId } from '../projects/projectsSlice';
 import { IMAGE_QUERY_LIMITS } from '../../config';
 import { setFocus, setSelectedImageIndices } from '../review/reviewSlice';
 
@@ -227,8 +228,7 @@ export const fetchImages = (filters, page = 'current') => {
       dispatch(getImagesStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const selectedProj = selectSelectedProject(getState());
       const pageInfo = getState().images.pageInfo;
 
       if (token && selectedProj) {
@@ -257,12 +257,11 @@ export const fetchImagesCount = (filters) => {
       dispatch(getImagesCountStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         let res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'getImagesCount',
           input: { filters },
         });
@@ -287,12 +286,11 @@ export const fetchImageContext = (imgId) => {
       dispatch(getImageContextStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         let res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'getImage',
           input: { imageId: imgId },
         });
@@ -332,12 +330,11 @@ export const deleteImages = (imageIds) => async (dispatch, getState) => {
     const currentUser = await Auth.currentAuthenticatedUser();
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
 
-    const projects = getState().projects.projects;
-    const selectedProj = projects.find((proj) => proj.selected);
+    const projId = selectSelectedProjectId(getState());
 
-    if (token && selectedProj) {
+    if (token && projId) {
       await call({
-        projId: selectedProj._id,
+        projId,
         request: 'deleteImages',
         input: { imageIds },
       });

--- a/src/features/projects/DeleteViewForm.jsx
+++ b/src/features/projects/DeleteViewForm.jsx
@@ -20,6 +20,9 @@ const DeleteViewForm = ({ handleClose }) => {
   const [queuedForClose, setQueuedForClose] = useState(false);
   const viewsLoading = useSelector(selectViewsLoading);
   const selectedView = useSelector(selectSelectedView);
+  // hold on to the view this form was opened for: a successful deletion selects
+  // the default view, and the form stays mounted until the effect below closes it
+  const [viewToDelete] = useState(selectedView);
   const dispatch = useDispatch();
 
   // TODO: extract into hook?
@@ -41,14 +44,15 @@ const DeleteViewForm = ({ handleClose }) => {
       )}
       <FormWrapper>
         <Formik
-          initialValues={{ viewId: selectedView._id }}
+          initialValues={{ viewId: viewToDelete._id }}
           validationSchema={deleteViewSchema}
           onSubmit={(values) => handleDeleteViewSubmit(values)}
         >
           {() => (
             <Form>
               <HelperText>
-                Are you sure you&apos;d like to delete the <ViewName>{selectedView.name}</ViewName> view?
+                Are you sure you&apos;d like to delete the <ViewName>{viewToDelete.name}</ViewName>{' '}
+                view?
               </HelperText>
               <Field name="viewId" type="hidden" />
               <ButtonRow>

--- a/src/features/projects/EditProjectForm.jsx
+++ b/src/features/projects/EditProjectForm.jsx
@@ -20,11 +20,15 @@ import { SimpleSpinner, SpinnerOverlay } from '../../components/Spinner.jsx';
 import { buildLocation } from '../../app/utils.js';
 
 import {
-  fetchProjects,
+  fetchProjectStubs,
+  fetchEditingProject,
+  clearEditingProject,
   fetchModelOptions,
   updateProject,
-  selectProjects,
-  selectProjectsLoading,
+  selectProjectStubs,
+  selectProjectStubsLoading,
+  selectEditingProject,
+  selectEditingProjectLoading,
   selectModelOptions,
   selectModelOptionsLoading,
   selectUpdateProjectLoading,
@@ -175,18 +179,15 @@ const NonRemovableMultiValueRemove = (existingModelIds) => {
 
 const EditProjectForm = () => {
   const dispatch = useDispatch();
-  const projects = useSelector(selectProjects);
-  const projectsLoading = useSelector(selectProjectsLoading);
+  const projectStubs = useSelector(selectProjectStubs);
+  const projectStubsLoading = useSelector(selectProjectStubsLoading);
+  const selectedProject = useSelector(selectEditingProject);
+  const editingProjectLoading = useSelector(selectEditingProjectLoading);
   const mlModels = useSelector(selectModelOptions);
   const mlModelsOptionsIsLoading = useSelector(selectModelOptionsLoading);
   const updateProjectIsLoading = useSelector(selectUpdateProjectLoading);
   const [selectedProjectId, setSelectedProjectId] = useState(null);
   const [inferredTimezone, setInferredTimezone] = useState(null);
-
-  const selectedProject = useMemo(
-    () => projects.find((p) => p._id === selectedProjectId),
-    [projects, selectedProjectId],
-  );
 
   const initialValues = useMemo(
     () =>
@@ -220,10 +221,10 @@ const EditProjectForm = () => {
 
   const projectOptions = useMemo(
     () =>
-      projects
+      projectStubs
         .filter((p) => p._id !== 'default_project')
         .map((p) => ({ value: p._id, label: p.name })),
-    [projects],
+    [projectStubs],
   );
 
   const mlModelOptions = useMemo(
@@ -236,19 +237,26 @@ const EditProjectForm = () => {
   );
 
   useEffect(() => {
-    dispatch(fetchProjects());
+    dispatch(fetchProjectStubs());
     dispatch(fetchModelOptions());
+    return () => {
+      dispatch(clearEditingProject());
+    };
   }, []);
 
   const handleProjectSelect = useCallback(
     (name, { value }) => {
       setSelectedProjectId(value);
-      dispatch(fetchProjects({ _ids: [value] }));
+      dispatch(fetchEditingProject(value));
     },
     [dispatch],
   );
 
-  const isLoading = projectsLoading.isLoading || mlModelsOptionsIsLoading || updateProjectIsLoading;
+  const isLoading =
+    projectStubsLoading.isLoading ||
+    editingProjectLoading.isLoading ||
+    mlModelsOptionsIsLoading ||
+    updateProjectIsLoading;
 
   return (
     <>
@@ -275,7 +283,7 @@ const EditProjectForm = () => {
           </FormFieldWrapper>
         </FieldRow>
 
-        {selectedProject && (
+        {selectedProject && selectedProject._id === selectedProjectId && (
           <Formik
             key={selectedProjectId}
             initialValues={initialValues}
@@ -286,7 +294,7 @@ const EditProjectForm = () => {
               if (Object.keys(diffs).length === 0) return;
               dispatch(
                 updateProject(selectedProjectId, diffs, () => {
-                  dispatch(fetchProjects({ _ids: [selectedProjectId] }));
+                  dispatch(fetchEditingProject(selectedProjectId));
                 }),
               );
             }}

--- a/src/features/projects/ProjectAndViewNav.jsx
+++ b/src/features/projects/ProjectAndViewNav.jsx
@@ -1,24 +1,17 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { styled } from '../../theme/stitches.config.js';
 import { SimpleSpinner } from '../../components/Spinner.jsx';
 import {
-  fetchProjects,
-  selectProjects,
-  selectSelectedProject,
-  selectProjectsLoading,
+  selectProjectStubs,
+  selectSelectedProjectId,
+  selectSelectedViewId,
+  selectProjectStubsLoading,
+  selectProjectLoading,
   selectViews,
-  selectSelectedView,
   selectUnsavedViewChanges,
-  setSelectedProjAndView,
 } from './projectsSlice.js';
-import {
-  selectRouterLocation,
-  fetchImageContext,
-  preFocusImageStart,
-  clearImages,
-} from '../images/imagesSlice.js';
 import {
   NavigationMenu,
   NavigationMenuList,
@@ -157,105 +150,57 @@ const ViewportPosition = styled('div', {
 });
 
 const ProjectAndViewNav = () => {
-  const projectsLoading = useSelector(selectProjectsLoading);
-  const projects = useSelector(selectProjects);
-  const selectedProj = useSelector(selectSelectedProject);
+  const stubsLoading = useSelector(selectProjectStubsLoading);
+  const projectLoading = useSelector(selectProjectLoading);
+  const projectStubs = useSelector(selectProjectStubs);
+  const selectedProjectId = useSelector(selectSelectedProjectId);
+  const selectedViewId = useSelector(selectSelectedViewId);
   const views = useSelector(selectViews);
-  const selectedView = useSelector(selectSelectedView);
   const unsavedViewChanges = useSelector(selectUnsavedViewChanges);
-  const routerLocation = useSelector(selectRouterLocation);
-  const paths = routerLocation.pathname.split('/').filter((p) => p.length > 0);
-  const appActive = paths[0] === 'app';
   const dispatch = useDispatch();
 
-  // fetch projects
-  useEffect(() => {
-    const { isLoading, noneFound, errors } = projectsLoading;
-    if (!projects.length && !isLoading && !noneFound && !errors) {
-      dispatch(fetchProjects());
-    }
-  }, [projects, projectsLoading, dispatch]);
-
-  // push initial selected project & view to URL
-  useEffect(() => {
-    if (appActive) {
-      const { projIdInPath, viewIdInPath } = getIdsFromPath(routerLocation);
-      const projectsReady = !projectsLoading.isLoading && projects.length;
-      const idsInPath = projIdInPath && viewIdInPath;
-
-      if (projectsReady && !idsInPath && !unsavedViewChanges) {
-        // TODO: check that there are projects & views in state that match the Ids
-        const projId = projIdInPath || projects[0]._id;
-        const proj = projects.find((p) => p._id === projId);
-        const defaultView = proj.views.find((v) => v.name === 'All images');
-        const viewId = viewIdInPath || defaultView._id;
-        dispatch(push(`/app/${projId}/${viewId}`));
-      }
-    }
-  }, [projects, projectsLoading, unsavedViewChanges, routerLocation, appActive, dispatch]);
-
-  // react to changes in URL & dispatch selected project and view to state
-  useEffect(() => {
-    if (appActive) {
-      const { projIdInPath, viewIdInPath } = getIdsFromPath(routerLocation);
-      const projectsReady = !projectsLoading.isLoading && projects.length;
-      const idsInPath = projIdInPath && viewIdInPath;
-
-      if (projectsReady && idsInPath) {
-        // TODO: check that there are projects & views in state that match the Ids
-        dispatch(
-          setSelectedProjAndView({
-            projId: projIdInPath,
-            viewId: viewIdInPath,
-          }),
-        );
-
-        // if 'img' detected in query params,
-        // kick off pre-focused-image initialization sequence
-        const query = routerLocation.query;
-        if ('img' in query && validateImgId(query.img)) {
-          dispatch(preFocusImageStart(query.img));
-          dispatch(fetchImageContext(query.img));
-        }
-      }
-    }
-  }, [projects.length, projectsLoading, routerLocation, appActive, dispatch]);
+  // Project & View selection is driven entirely by the URL and reconciled in
+  // projectsListeners.js. This component only renders the menus and pushes new
+  // URLs; it never reads or writes selection state directly.
+  const selectedProjStub = projectStubs.find((p) => p._id === selectedProjectId);
+  const selectedView = views?.find((v) => v._id === selectedViewId);
+  const isLoading = stubsLoading.isLoading || projectLoading.isLoading;
 
   const handleProjectMenuItemClick = (projId) => {
-    if (projId === selectedProj._id) return;
-    const project = projects.find((p) => p._id === projId);
-    const viewId = project.views.find((v) => v.name === 'All images')._id;
-    dispatch(clearImages());
-    dispatch(push(`/app/${projId}/${viewId}`));
+    if (projId === selectedProjectId) return;
+    const project = projectStubs.find((p) => p._id === projId);
+    const defaultView = project.views.find((v) => v.name === 'All images') ?? project.views[0];
+    if (!defaultView) return;
+    dispatch(push(`/app/${projId}/${defaultView._id}`));
   };
 
   const handleViewMenuItemClick = (viewId) => {
-    if (viewId === selectedView._id) return;
-    dispatch(push(`/app/${selectedProj._id}/${viewId}`));
+    if (viewId === selectedViewId) return;
+    dispatch(push(`/app/${selectedProjectId}/${viewId}`));
   };
 
   return (
     <NavigationMenu css={{ justifyContent: 'center', width: '100vw' }}>
-      <SimpleSpinner size="sm" display={projectsLoading.isLoading} />
-      {projectsLoading.noneFound && (
+      <SimpleSpinner size="sm" display={isLoading} />
+      {stubsLoading.noneFound && (
         <NoneFoundAlert>Rats! You don&apos;t have access to any projects yet!</NoneFoundAlert>
       )}
-      {selectedView && (
+      {selectedProjStub && selectedView && (
         <NavigationMenuList>
           <NavigationMenuItem>
             <NavigationMenuTriggerWithCaret onPointerMove={(e) => e.preventDefault()}>
-              <NavigationMenuTriggerText>{selectedProj.name}</NavigationMenuTriggerText>
+              <NavigationMenuTriggerText>{selectedProjStub.name}</NavigationMenuTriggerText>
             </NavigationMenuTriggerWithCaret>
             <NavigationMenuContent onPointerMove={(e) => e.preventDefault()}>
               <MenuTitle>Projects</MenuTitle>
               <ContentList layout="one">
-                {projects
+                {projectStubs
                   .toSorted((a, b) => a.name.localeCompare(b.name))
                   .map((proj) => (
                     <ContentListItem
                       key={proj._id}
                       title={proj.name}
-                      selected={proj.selected}
+                      selected={proj._id === selectedProjectId}
                       onClick={() => handleProjectMenuItemClick(proj._id)}
                     >
                       {proj.description}
@@ -281,7 +226,7 @@ const ProjectAndViewNav = () => {
                     <ContentListItem
                       key={view._id}
                       title={view.name}
-                      selected={view.selected}
+                      selected={view._id === selectedViewId}
                       onClick={() => handleViewMenuItemClick(view._id)}
                     >
                       {view.description}
@@ -301,16 +246,5 @@ const ProjectAndViewNav = () => {
     </NavigationMenu>
   );
 };
-
-function validateImgId(imgId) {
-  const hash = imgId.includes(':') ? imgId.split(':')[1] : imgId;
-  const regexExp = /^[a-f0-9]{32}$/gi;
-  return regexExp.test(hash);
-}
-
-function getIdsFromPath(routerLocation) {
-  let paths = routerLocation.pathname.split('/').filter((p) => p.length > 0);
-  return { projIdInPath: paths[1], viewIdInPath: paths[2] };
-}
 
 export default ProjectAndViewNav;

--- a/src/features/projects/projectsListeners.js
+++ b/src/features/projects/projectsListeners.js
@@ -1,0 +1,156 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit';
+import { LOCATION_CHANGE, replace } from 'connected-react-router';
+import { batch } from 'react-redux';
+import {
+  fetchProject,
+  fetchProjectStubs,
+  getProjectStubsSuccess,
+  projectChanged,
+  selectProjectStubs,
+  selectProjectStubsLoading,
+  selectSelectedProject,
+  selectSelectedProjectId,
+  selectSelectedViewId,
+  setSelectedProjAndView,
+} from './projectsSlice';
+import {
+  clearImages,
+  fetchImageContext,
+  preFocusImageStart,
+  selectRouterLocation,
+} from '../images/imagesSlice';
+import { selectUserAuthStatus, userAuthStateChanged } from '../user/userSlice';
+
+export const projectsListener = createListenerMiddleware();
+
+const APP_PATH = 'app';
+
+// `/app/:projId/:viewId`
+function getIdsFromPath(pathname) {
+  const paths = pathname.split('/').filter((p) => p.length > 0);
+  return {
+    appActive: paths[0] === APP_PATH,
+    projIdInPath: paths[1],
+    viewIdInPath: paths[2],
+  };
+}
+
+function isValidImgId(imgId) {
+  const hash = imgId.includes(':') ? imgId.split(':')[1] : imgId;
+  return /^[a-f0-9]{32}$/i.test(hash);
+}
+
+// every Project is created with an "All images" view, but fall back to the first
+// view we know about so a malformed Project can't wedge the router in a loop
+function findDefaultViewId(views) {
+  if (!views?.length) return null;
+  return (views.find((v) => v.name === 'All images') ?? views[0])._id;
+}
+
+/**
+ * Single source of truth for Project & View selection.
+ *
+ * The URL drives Redux, never the other way around: this listener reads
+ * `/app/:projId/:viewId`, fills in any missing or invalid segments by issuing a
+ * `replace()` (which re-triggers this listener), and only once the URL is fully
+ * resolved does it fetch Project detail and commit the selection to state.
+ *
+ * NOTE: this app renders with React 16 via `ReactDOM.render`, so React only
+ * auto-batches dispatches made from its own event handlers and effect flushes.
+ * This effect runs in a promise microtask, outside React, so every related group
+ * of dispatches MUST be wrapped in `batch()`. Without it each dispatch forces a
+ * separate render and `ImagesPanel` fires `fetchImages` against half-applied
+ * state (e.g. a new project id but the previous view's filters).
+ */
+projectsListener.startListening({
+  predicate: (action) =>
+    action.type === LOCATION_CHANGE ||
+    getProjectStubsSuccess.match(action) ||
+    userAuthStateChanged.match(action),
+  effect: async (action, listenerApi) => {
+    // a newer navigation supersedes any reconciliation still in flight
+    listenerApi.cancelActiveListeners();
+
+    const state = listenerApi.getState();
+
+    // the initial LOCATION_CHANGE fires before Amplify has resolved the session,
+    // so wait for authentication before touching the API. this listener re-runs
+    // on userAuthStateChanged.
+    if (selectUserAuthStatus(state) !== 'authenticated') return;
+
+    const routerLocation = selectRouterLocation(state);
+    const { appActive, projIdInPath, viewIdInPath } = getIdsFromPath(routerLocation.pathname);
+    if (!appActive) return;
+
+    // must be read before this effect awaits anything - RTK only allows
+    // getOriginalState() to be called synchronously
+    const prevImgId = selectRouterLocation(listenerApi.getOriginalState()).query?.img;
+
+    // 1. make sure we know which Projects the user has access to
+    const stubs = selectProjectStubs(state);
+    const stubsLoading = selectProjectStubsLoading(state);
+    if (!stubs.length) {
+      if (!stubsLoading.isLoading && !stubsLoading.noneFound && !stubsLoading.errors) {
+        // this listener re-runs on getProjectStubsSuccess
+        listenerApi.dispatch(fetchProjectStubs());
+      }
+      return;
+    }
+
+    // 2. resolve the Project in the URL, falling back to the first one
+    const projStub = stubs.find((p) => p._id === projIdInPath) ?? stubs[0];
+    const defaultViewId = findDefaultViewId(projStub.views);
+    if (!defaultViewId) return; // Project has no views; nothing to navigate to
+    if (projStub._id !== projIdInPath) {
+      listenerApi.dispatch(replace(`/${APP_PATH}/${projStub._id}/${defaultViewId}`));
+      return;
+    }
+
+    // 3. resolve the View in the URL, falling back to "All images"
+    const viewInStub = projStub.views.some((v) => v._id === viewIdInPath);
+    if (!viewInStub) {
+      listenerApi.dispatch(replace(`/${APP_PATH}/${projStub._id}/${defaultViewId}`));
+      return;
+    }
+
+    // 4. fetch Project detail if we don't already have it
+    if (selectSelectedProject(listenerApi.getState())?._id !== projStub._id) {
+      batch(() => {
+        listenerApi.dispatch(projectChanged(projStub._id));
+        listenerApi.dispatch(clearImages());
+      });
+      await listenerApi.dispatch(fetchProject(projStub._id));
+      if (selectSelectedProject(listenerApi.getState())?._id !== projStub._id) {
+        return; // fetch failed; the error toast will explain why
+      }
+    }
+
+    const currentState = listenerApi.getState();
+    const projChanged = selectSelectedProjectId(currentState) !== projStub._id;
+    const viewChanged = selectSelectedViewId(currentState) !== viewIdInPath;
+    const imgId = routerLocation.query?.img;
+    const focusImage =
+      imgId && isValidImgId(imgId) && (projChanged || viewChanged || imgId !== prevImgId);
+
+    batch(() => {
+      // 5. commit the selection. dispatching setSelectedProjAndView also runs
+      // the setActiveFiltersToSelectedView middleware, so the new project, view
+      // and filters all land in the same render.
+      if (projChanged || viewChanged) {
+        listenerApi.dispatch(
+          setSelectedProjAndView({ projId: projStub._id, viewId: viewIdInPath }),
+        );
+      }
+
+      // 6. if 'img' is in the query params, kick off the pre-focused-image
+      // initialization sequence. This has to share a batch with step 5 so that
+      // getImageContextStart (dispatched synchronously by fetchImageContext) is
+      // applied before ImagesPanel re-renders - it's what stops the panel from
+      // fetching the view's images out from under the image we're focusing.
+      if (focusImage) {
+        listenerApi.dispatch(preFocusImageStart(imgId));
+        listenerApi.dispatch(fetchImageContext(imgId));
+      }
+    });
+  },
+});

--- a/src/features/projects/projectsMiddleware.js
+++ b/src/features/projects/projectsMiddleware.js
@@ -11,7 +11,6 @@ import {
   checkboxOnlyButtonClicked,
 } from '../filters/filtersSlice';
 import {
-  selectProjects,
   setSelectedProjAndView,
   saveViewSuccess,
   selectSelectedView,
@@ -20,47 +19,19 @@ import {
 } from './projectsSlice';
 import { editDeploymentsSuccess } from '../tasks/tasksSlice';
 
-// enrich newly selected project and view payload
-export const enrichProjAndViewPayload = (store) => (next) => (action) => {
-  if (setSelectedProjAndView.match(action)) {
-    let { projId, viewId } = action.payload;
+// filter categories stored as arrays of ids
+const ID_FILTER_CATEGORIES = ['cameras', 'deployments', 'labels', 'tags'];
 
-    // add project to payload (used in filtersSlice extraReducers)
-    const projects = selectProjects(store.getState());
-    const projToSelect = projects.find((proj) => proj._id === projId);
-    action.payload.project = projToSelect;
+// Toggling an id off and back on appends it to the end of the array, so the
+// order of these arrays carries no meaning. Sort them before diffing, otherwise
+// manually restoring a view's filters can leave the view looking "edited".
+const sortIdFilters = (filters) =>
+  _.mapValues(filters, (value, category) =>
+    ID_FILTER_CATEGORIES.includes(category) && Array.isArray(value) ? [...value].sort() : value,
+  );
 
-    // add default viewId to payload if not specified in payload
-    if (!viewId) {
-      const defaultView = projToSelect.views.find((v) => v.name === 'All images');
-      action.payload.viewId = defaultView._id;
-      viewId = defaultView._id;
-    }
-
-    // find and add view to payload (used in setSelectedViewMiddleware)
-    projects.forEach((p) => {
-      p.views.forEach((v) => {
-        if (v._id === viewId) action.payload.view = v;
-      });
-    });
-
-    // indicate whether there will be a view and/or project change
-    const currSelectedProj = projects.find((p) => p.selected);
-    if (currSelectedProj) {
-      const currSelectedView = currSelectedProj.views.find((v) => v.selected);
-      action.payload.newProjSelected = currSelectedProj._id !== projId;
-      action.payload.newViewSelected = currSelectedView._id !== viewId;
-    } else {
-      // we're setting selected project for the first time
-      action.payload.newProjSelected = true;
-      action.payload.newViewSelected = true;
-    }
-
-    next(action);
-  } else {
-    next(action);
-  }
-};
+const filtersMatch = (activeFilters, viewFilters) =>
+  _.isEqual(sortIdFilters(activeFilters), sortIdFilters(viewFilters));
 
 // track whether active filters match selected view filters
 export const diffFilters = (store) => (next) => (action) => {
@@ -81,8 +52,7 @@ export const diffFilters = (store) => (next) => (action) => {
     const activeFilters = selectActiveFilters(store.getState());
     const selectedView = selectSelectedView(store.getState());
     if (activeFilters && selectedView) {
-      const match = _.isEqual(activeFilters, selectedView.filters);
-      store.dispatch(setUnsavedViewChanges(!match));
+      store.dispatch(setUnsavedViewChanges(!filtersMatch(activeFilters, selectedView.filters)));
     }
   } else {
     next(action);
@@ -97,8 +67,10 @@ export const setActiveFiltersToSelectedView = (store) => (next) => (action) => {
     store.dispatch(undoActions.clear());
 
     next(action);
-    const newFilters = action.payload.view.filters;
-    store.dispatch(setActiveFilters(newFilters));
+    // read the newly selected view back out of state rather than off the action
+    // payload, so callers only ever have to supply { projId, viewId }
+    const selectedView = selectSelectedView(store.getState());
+    if (selectedView) store.dispatch(setActiveFilters(selectedView.filters));
   } else {
     next(action);
   }

--- a/src/features/projects/projectsSlice.js
+++ b/src/features/projects/projectsSlice.js
@@ -19,6 +19,9 @@ const initialState = {
   editingProject: null,
   selectedProjectId: null,
   selectedViewId: null,
+  // id of the most recently requested Project detail fetch, used to discard
+  // responses that have been superseded by a newer selection
+  requestedProjectId: null,
   modelOptions: [],
   loadingStates: {
     projectStubs: {
@@ -149,9 +152,10 @@ export const projectsSlice = createSlice({
       state.loadingStates.projectStubs.errors.splice(index, 1);
     },
 
-    getProjectStart: (state) => {
+    getProjectStart: (state, { payload }) => {
       const ls = { isLoading: true, operation: 'fetching', errors: null };
       state.loadingStates.project = ls;
+      state.requestedProjectId = payload;
     },
 
     getProjectFailure: (state, { payload }) => {
@@ -719,20 +723,25 @@ export const fetchProjectStubs = () => async (dispatch) => {
 };
 
 // fetch full detail for a single Project
-export const fetchProject = (projId) => async (dispatch) => {
+export const fetchProject = (projId) => async (dispatch, getState) => {
   try {
     const currentUser = await Auth.currentAuthenticatedUser();
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
 
     if (token) {
-      dispatch(getProjectStart());
+      dispatch(getProjectStart(projId));
       const res = await call({ request: 'getProject', input: projId });
+      // the user may have selected a different Project while this was in
+      // flight. bail rather than let a slow response overwrite a newer one -
+      // filtersSlice also derives its available filters from getProjectSuccess.
+      if (selectRequestedProjectId(getState()) !== projId) return;
       const project = res.projects[0];
       if (!project) throw new Error(`Project ${projId} not found`);
       dispatch(getProjectSuccess({ project }));
     }
   } catch (err) {
     console.log('err: ', err);
+    if (selectRequestedProjectId(getState()) !== projId) return;
     const errs = normalizeErrors(err, 'GET_PROJECTS_ERROR');
     dispatch(getProjectFailure(errs));
   }
@@ -1126,6 +1135,7 @@ export const deleteProjectLabel = (payload) => {
 export const selectProjectStubs = (state) => state.projects.projectStubs;
 export const selectSelectedProject = (state) => state.projects.project;
 export const selectSelectedProjectId = (state) => state.projects.selectedProjectId;
+export const selectRequestedProjectId = (state) => state.projects.requestedProjectId;
 export const selectSelectedViewId = (state) => state.projects.selectedViewId;
 export const selectEditingProject = (state) => state.projects.editingProject;
 export const selectEditingProjectLoading = (state) => state.projects.loadingStates.editingProject;
@@ -1153,6 +1163,12 @@ export const selectProjectTagsLoading = (state) =>
   state.projects.loadingStates.projectTags.isLoading;
 export const selectProjectStubsLoading = (state) => state.projects.loadingStates.projectStubs;
 export const selectProjectLoading = (state) => state.projects.loadingStates.project;
+// true while either the Project list or the selected Project's detail is in
+// flight - between them they cover the whole "we don't have a Project yet" window
+export const selectAnyProjectLoading = createSelector(
+  [selectProjectStubsLoading, selectProjectLoading],
+  (stubs, project) => stubs.isLoading || project.isLoading,
+);
 export const selectViewsLoading = (state) => state.projects.loadingStates.views;
 export const selectAutomationRulesLoading = (state) => state.projects.loadingStates.automationRules;
 export const selectModelsLoadingState = (state) => state.projects.loadingStates.models;

--- a/src/features/projects/projectsSlice.js
+++ b/src/features/projects/projectsSlice.js
@@ -1,5 +1,6 @@
 import { createSlice, createSelector } from '@reduxjs/toolkit';
 import { Auth } from 'aws-amplify';
+import { push } from 'connected-react-router';
 import { call } from '../../api';
 import { registerCameraSuccess, unregisterCameraSuccess } from '../cameras/wirelessCamerasSlice';
 import { deleteProjectLabelTaskStart, editDeploymentsSuccess } from '../tasks/tasksSlice';
@@ -7,14 +8,34 @@ import { clearImages } from '../images/imagesSlice.js';
 import { normalizeErrors } from '../../app/utils.js';
 
 const initialState = {
-  projects: [],
+  // lightweight stubs for every Project the user has access to.
+  // shape: { _id, name, description, views: [{ _id, name }] }
+  projectStubs: [],
+  // full detail for the currently selected Project (or null while loading)
+  project: null,
+  // full detail for a Project being edited in the superuser EditProjectForm.
+  // deliberately kept separate from `project` because a superuser can edit a
+  // Project other than the one they currently have open.
+  editingProject: null,
+  selectedProjectId: null,
+  selectedViewId: null,
   modelOptions: [],
   loadingStates: {
-    projects: {
+    projectStubs: {
       isLoading: false,
       operation: null /* 'fetching', 'updating', 'deleting' */,
       errors: null,
       noneFound: false,
+    },
+    project: {
+      isLoading: false,
+      operation: null,
+      errors: null,
+    },
+    editingProject: {
+      isLoading: false,
+      operation: null,
+      errors: null,
     },
     createProject: {
       isLoading: false,
@@ -76,60 +97,121 @@ const initialState = {
   automationRules: [],
 };
 
+const findDefaultViewId = (views) => views?.find((v) => v.name === 'All images')?._id ?? null;
+
+// derive the lightweight nav-menu representation of a Project from full detail
+const toProjectStub = (project) => ({
+  _id: project._id,
+  name: project.name,
+  description: project.description,
+  views: (project.views || []).map((v) => ({ _id: v._id, name: v.name })),
+});
+
+// keep the nav-menu stub in sync whenever we learn something new about a Project
+const syncProjectStub = (state, project) => {
+  const idx = state.projectStubs.findIndex((stub) => stub._id === project._id);
+  if (idx !== -1) state.projectStubs[idx] = toProjectStub(project);
+};
+
+// keep a Project's stub views in sync after a view is created/updated/deleted
+const syncProjectStubViews = (state, projId, views) => {
+  const stub = state.projectStubs.find((s) => s._id === projId);
+  if (stub) stub.views = views.map((v) => ({ _id: v._id, name: v.name }));
+};
+
 export const projectsSlice = createSlice({
   name: 'projects',
   initialState,
   reducers: {
-    getProjectsStart: (state) => {
-      const ls = { isLoading: true, operation: 'fetching', errors: null };
-      state.loadingStates.projects = ls;
+    getProjectStubsStart: (state) => {
+      const ls = { isLoading: true, operation: 'fetching', errors: null, noneFound: false };
+      state.loadingStates.projectStubs = ls;
     },
 
-    getProjectsFailure: (state, { payload }) => {
-      const ls = { isLoading: false, operation: null, errors: payload };
-      state.loadingStates.projects = ls;
+    getProjectStubsFailure: (state, { payload }) => {
+      const ls = { isLoading: false, operation: null, errors: payload, noneFound: false };
+      state.loadingStates.projectStubs = ls;
     },
 
-    getProjectsSuccess: (state, { payload }) => {
+    getProjectStubsSuccess: (state, { payload }) => {
       const noneFound = !payload.projects || payload.projects.length === 0;
-      const ls = { isLoading: false, operation: null, errors: null, noneFound };
-      state.loadingStates.projects = ls;
-      if (noneFound) {
-        state.projects = [];
-      } else if (state.projects.length) {
-        payload.projects.forEach((newProj) => {
-          const idx = state.projects.findIndex((oldProj) => oldProj._id === newProj._id);
-          if (idx !== -1) state.projects[idx] = newProj;
-        });
-      } else {
-        state.projects = payload.projects;
-      }
+      state.loadingStates.projectStubs = {
+        isLoading: false,
+        operation: null,
+        errors: null,
+        noneFound,
+      };
+      state.projectStubs = payload.projects || [];
     },
 
-    dismissProjectsError: (state, { payload }) => {
+    dismissProjectStubsError: (state, { payload }) => {
       const index = payload;
-      state.loadingStates.projects.errors.splice(index, 1);
+      state.loadingStates.projectStubs.errors.splice(index, 1);
+    },
+
+    getProjectStart: (state) => {
+      const ls = { isLoading: true, operation: 'fetching', errors: null };
+      state.loadingStates.project = ls;
+    },
+
+    getProjectFailure: (state, { payload }) => {
+      const ls = { isLoading: false, operation: null, errors: payload };
+      state.loadingStates.project = ls;
+    },
+
+    getProjectSuccess: (state, { payload }) => {
+      const ls = { isLoading: false, operation: null, errors: null };
+      state.loadingStates.project = ls;
+      state.project = payload.project;
+      syncProjectStub(state, payload.project);
+    },
+
+    dismissProjectError: (state, { payload }) => {
+      const index = payload;
+      state.loadingStates.project.errors.splice(index, 1);
+    },
+
+    getEditingProjectStart: (state) => {
+      const ls = { isLoading: true, operation: 'fetching', errors: null };
+      state.loadingStates.editingProject = ls;
+    },
+
+    getEditingProjectFailure: (state, { payload }) => {
+      const ls = { isLoading: false, operation: null, errors: payload };
+      state.loadingStates.editingProject = ls;
+    },
+
+    getEditingProjectSuccess: (state, { payload }) => {
+      const ls = { isLoading: false, operation: null, errors: null };
+      state.loadingStates.editingProject = ls;
+      state.editingProject = payload.project;
+    },
+
+    clearEditingProject: (state) => {
+      state.editingProject = null;
+      state.loadingStates.editingProject = { isLoading: false, operation: null, errors: null };
+    },
+
+    // dispatched when the user navigates to a different Project, before that
+    // Project's detail has been fetched. Other slices listen for this to reset
+    // their project-scoped state.
+    //
+    // NOTE: `project` is deliberately left in place until the incoming Project's
+    // detail lands. Clearing the selected ids is enough to make the nav, the
+    // images panel and the view-dependent controls go quiet, and it avoids
+    // yanking labels/tags/cameraConfigs out from under components that are still
+    // mounted while the fetch is in flight.
+    projectChanged: (state) => {
+      state.selectedProjectId = null;
+      state.selectedViewId = null;
+      state.unsavedViewChanges = false;
+      state.loadingStates.project.errors = null;
+      state.loadingStates.models.errors = null;
     },
 
     setSelectedProjAndView: (state, { payload }) => {
-      let selectedProj = state.projects.find((p) => p.selected);
-
-      if (payload.newProjSelected) {
-        state.projects.forEach((p) => {
-          p.selected = p._id === payload.projId;
-          if (p._id === payload.projId) selectedProj = p;
-        });
-
-        state.loadingStates.projects.errors = null;
-        state.loadingStates.models.errors = null;
-      }
-
-      if (payload.newViewSelected) {
-        selectedProj.views.forEach((v) => {
-          v.selected = v._id === payload.viewId;
-        });
-      }
-
+      state.selectedProjectId = payload.projId;
+      state.selectedViewId = payload.viewId ?? findDefaultViewId(state.project?.views);
       state.loadingStates.views.errors = null;
     },
 
@@ -151,7 +233,7 @@ export const projectsSlice = createSlice({
       };
       state.loadingStates.createProject = ls;
 
-      state.projects = [...state.projects, project];
+      state.projectStubs.push(toProjectStub(project));
       state.successNotif = {
         title: 'Created Project',
         message: 'Project created successfully!',
@@ -177,8 +259,9 @@ export const projectsSlice = createSlice({
       const { project } = payload.updateProject;
       const ls = { isLoading: false, operation: null, errors: null };
       state.loadingStates.updateProject = ls;
-      const idx = state.projects.findIndex((p) => p._id === project._id);
-      if (idx !== -1) state.projects[idx] = project;
+      if (state.project?._id === project._id) state.project = project;
+      if (state.editingProject?._id === project._id) state.editingProject = project;
+      syncProjectStub(state, project);
       state.successNotif = {
         title: 'Updated Project',
         message: 'Project updated successfully!',
@@ -219,16 +302,14 @@ export const projectsSlice = createSlice({
       };
       state.loadingStates.views = ls;
 
-      let viewInState = false;
-      const proj = state.projects.find((p) => p._id === payload.projId);
-      proj.views.forEach((view, i) => {
-        if (view._id === payload.view._id) {
-          viewInState = true;
-          proj.views[i] = { ...proj.views[i], ...payload.view };
+      if (state.project?._id === payload.projId) {
+        const idx = state.project.views.findIndex((v) => v._id === payload.view._id);
+        if (idx !== -1) {
+          state.project.views[idx] = { ...state.project.views[idx], ...payload.view };
+        } else {
+          state.project.views.push(payload.view);
         }
-      });
-      if (!viewInState) {
-        proj.views.push(payload.view);
+        syncProjectStubViews(state, payload.projId, state.project.views);
       }
       state.successNotif = {
         title: 'View Saved',
@@ -240,8 +321,10 @@ export const projectsSlice = createSlice({
       const ls = { isLoading: false, operation: null, errors: null };
       state.loadingStates.views = ls;
 
-      const proj = state.projects.find((p) => p._id === payload.projId);
-      proj.views = proj.views.filter((view) => view._id !== payload.viewId);
+      if (state.project?._id === payload.projId) {
+        state.project.views = state.project.views.filter((view) => view._id !== payload.viewId);
+        syncProjectStubViews(state, payload.projId, state.project.views);
+      }
     },
 
     dismissViewsError: (state, { payload }) => {
@@ -319,7 +402,8 @@ export const projectsSlice = createSlice({
       const ls = { isLoading: false, operation: null, errors: null };
       state.loadingStates.models = ls;
 
-      const proj = state.projects.find((p) => p._id === payload.projId);
+      if (state.project?._id !== payload.projId) return;
+      const proj = state.project;
       payload.mlModels.forEach((model) => {
         if (!proj.mlModels) proj.mlModels = [model];
         else if (!proj.mlModels.includes(model._id)) proj.mlModels.push(model);
@@ -363,8 +447,7 @@ export const projectsSlice = createSlice({
         errors: null,
       };
       state.loadingStates.projectLabels = ls;
-      const proj = state.projects.find((p) => p._id === payload.projId);
-      proj.labels = payload.labels;
+      if (state.project?._id === payload.projId) state.project.labels = payload.labels;
     },
 
     createProjectLabelFailure: (state, { payload }) => {
@@ -384,8 +467,7 @@ export const projectsSlice = createSlice({
         errors: null,
       };
       state.loadingStates.projectLabels = ls;
-      const proj = state.projects.find((p) => p._id === payload.projId);
-      proj.labels = payload.labels;
+      if (state.project?._id === payload.projId) state.project.labels = payload.labels;
     },
 
     updateProjectLabelFailure: (state, { payload }) => {
@@ -430,8 +512,7 @@ export const projectsSlice = createSlice({
       };
       state.loadingStates.projectTags = ls;
 
-      const proj = state.projects.find((p) => p._id === payload.projId);
-      proj.tags = payload.tags;
+      if (state.project?._id === payload.projId) state.project.tags = payload.tags;
     },
 
     createProjectTagFailure: (state, { payload }) => {
@@ -448,8 +529,7 @@ export const projectsSlice = createSlice({
       const ls = { isLoading: false, operation: null, errors: null };
       state.loadingStates.projectTags = ls;
 
-      const proj = state.projects.find((p) => p._id === payload.projId);
-      proj.tags = payload.tags;
+      if (state.project?._id === payload.projId) state.project.tags = payload.tags;
     },
 
     deleteProjectTagFailure: (state, { payload }) => {
@@ -470,8 +550,7 @@ export const projectsSlice = createSlice({
       };
       state.loadingStates.projectTags = ls;
 
-      const proj = state.projects.find((p) => p._id === payload.projId);
-      proj.tags = payload.tags;
+      if (state.project?._id === payload.projId) state.project.tags = payload.tags;
     },
 
     updateProjectTagFailure: (state, { payload }) => {
@@ -511,22 +590,21 @@ export const projectsSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(registerCameraSuccess, (state, { payload }) => {
-        const proj = state.projects.find((p) => p._id === payload.project._id);
-        proj.cameraConfigs = payload.project.cameraConfigs;
+        if (state.project?._id !== payload.project._id) return;
+        state.project.cameraConfigs = payload.project.cameraConfigs;
       })
       .addCase(unregisterCameraSuccess, (state, { payload }) => {
         // if a project is returned & it's the default_project
         // update the default_project's cameraConfig array in state
         if (payload.project && payload.project._id === 'default_project') {
-          const defaultProj = state.projects.find((p) => p._id === 'default_project');
-          if (!defaultProj) return;
-          defaultProj.cameraConfigs = payload.project.cameraConfigs;
+          if (state.project?._id !== 'default_project') return;
+          state.project.cameraConfigs = payload.project.cameraConfigs;
         }
       })
       .addCase(editDeploymentsSuccess, (state, { payload }) => {
         const editedCamConfig = payload.cameraConfig;
-        const proj = state.projects.find((p) => p._id === payload.projId);
-        for (const camConfig of proj.cameraConfigs) {
+        if (state.project?._id !== payload.projId) return;
+        for (const camConfig of state.project.cameraConfigs) {
           if (camConfig._id === editedCamConfig._id) {
             camConfig.deployments = editedCamConfig.deployments;
           }
@@ -540,12 +618,24 @@ export const projectsSlice = createSlice({
 });
 
 export const {
-  getProjectsStart,
-  getProjectsFailure,
-  getProjectsSuccess,
+  getProjectStubsStart,
+  getProjectStubsFailure,
+  getProjectStubsSuccess,
+  dismissProjectStubsError,
+
+  getProjectStart,
+  getProjectFailure,
+  getProjectSuccess,
+  dismissProjectError,
+
+  getEditingProjectStart,
+  getEditingProjectFailure,
+  getEditingProjectSuccess,
+  clearEditingProject,
+
+  projectChanged,
   setSelectedProjAndView,
   setUnsavedViewChanges,
-  dismissProjectsError,
   dismissProjectTagErrors,
   createProjectStart,
   createProjectSuccess,
@@ -609,24 +699,64 @@ export const {
   setGlobalBreakpoint,
 } = projectsSlice.actions;
 
-// fetchProjects thunk
-export const fetchProjects = (payload) => async (dispatch) => {
+// fetch lightweight stubs for every Project the user has access to.
+// this is what populates the Project nav menu.
+export const fetchProjectStubs = () => async (dispatch) => {
   try {
     const currentUser = await Auth.currentAuthenticatedUser();
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
 
     if (token) {
-      dispatch(getProjectsStart());
-      const projects = await call({
-        request: 'getProjects',
-        ...(payload && { input: payload }),
-      });
-      dispatch(getProjectsSuccess(projects));
+      dispatch(getProjectStubsStart());
+      const projects = await call({ request: 'getProjectStubs' });
+      dispatch(getProjectStubsSuccess(projects));
     }
   } catch (err) {
     console.log('err: ', err);
     const errs = normalizeErrors(err, 'GET_PROJECTS_ERROR');
-    dispatch(getProjectsFailure(errs));
+    dispatch(getProjectStubsFailure(errs));
+  }
+};
+
+// fetch full detail for a single Project
+export const fetchProject = (projId) => async (dispatch) => {
+  try {
+    const currentUser = await Auth.currentAuthenticatedUser();
+    const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
+
+    if (token) {
+      dispatch(getProjectStart());
+      const res = await call({ request: 'getProject', input: projId });
+      const project = res.projects[0];
+      if (!project) throw new Error(`Project ${projId} not found`);
+      dispatch(getProjectSuccess({ project }));
+    }
+  } catch (err) {
+    console.log('err: ', err);
+    const errs = normalizeErrors(err, 'GET_PROJECTS_ERROR');
+    dispatch(getProjectFailure(errs));
+  }
+};
+
+// fetch full detail for an arbitrary Project, for the superuser EditProjectForm.
+// kept separate from fetchProject so editing a Project doesn't disturb the one
+// the user currently has open.
+export const fetchEditingProject = (projId) => async (dispatch) => {
+  try {
+    const currentUser = await Auth.currentAuthenticatedUser();
+    const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
+
+    if (token) {
+      dispatch(getEditingProjectStart());
+      const res = await call({ request: 'getProject', input: projId });
+      const project = res.projects[0];
+      if (!project) throw new Error(`Project ${projId} not found`);
+      dispatch(getEditingProjectSuccess({ project }));
+    }
+  } catch (err) {
+    console.log('err: ', err);
+    const errs = normalizeErrors(err, 'GET_PROJECTS_ERROR');
+    dispatch(getEditingProjectFailure(errs));
   }
 };
 
@@ -679,11 +809,18 @@ export const editView = (operation, payload) => {
       dispatch(editViewStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      // view selection lives in the URL, so navigate rather than dispatching
+      // setSelectedProjAndView directly. projectsListeners.js picks the change
+      // up and commits it to state.
+      const selectView = (viewId) => {
+        if (selectSelectedViewId(getState()) !== viewId) {
+          dispatch(push(`/app/${projId}/${viewId}`));
+        }
+      };
+
+      if (token && projId) {
         switch (operation) {
           case 'create': {
             const res = await call({
@@ -693,7 +830,7 @@ export const editView = (operation, payload) => {
             });
             const view = res.createView.view;
             dispatch(saveViewSuccess({ projId, view }));
-            dispatch(setSelectedProjAndView({ projId, viewId: view._id }));
+            selectView(view._id);
             break;
           }
           case 'update': {
@@ -704,7 +841,7 @@ export const editView = (operation, payload) => {
             });
             const view = res.updateView.view;
             dispatch(saveViewSuccess({ projId, view }));
-            dispatch(setSelectedProjAndView({ projId, viewId: view._id }));
+            selectView(view._id);
             break;
           }
           case 'delete': {
@@ -715,7 +852,10 @@ export const editView = (operation, payload) => {
             });
             const updatedProj = res.deleteView.project;
             const dfltView = updatedProj.views.find((view) => view.name === 'All images');
-            dispatch(setSelectedProjAndView({ projId, viewId: dfltView._id }));
+            // select the default view *before* removing the deleted one, so
+            // selectSelectedView never briefly resolves to undefined while
+            // DeleteViewForm is still mounted
+            selectView(dfltView._id);
             dispatch(deleteViewSuccess({ projId, viewId: payload.viewId }));
             break;
           }
@@ -739,11 +879,9 @@ export const updateAutomationRules = (payload) => {
       dispatch(updateAutomationRulesStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'updateAutomationRules',
@@ -766,11 +904,9 @@ export const fetchAutomationRules = () => {
       dispatch(getAutomationRulesStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           request: 'getProjectAutomationRules',
           input: { _ids: [projId] },
@@ -792,11 +928,9 @@ export const fetchModels = (payload) => {
       dispatch(getModelsStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'getModels',
@@ -838,11 +972,9 @@ export const createProjectTag = (payload) => {
       dispatch(createProjectTagStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'createProjectTag',
@@ -863,11 +995,9 @@ export const deleteProjectTag = (payload) => {
       dispatch(deleteProjectTagStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'deleteProjectTag',
@@ -875,7 +1005,7 @@ export const deleteProjectTag = (payload) => {
         });
         dispatch(deleteProjectTagSuccess({ projId, tags: res.deleteProjectTag.tags }));
         dispatch(clearImages());
-        dispatch(fetchProjects({ _ids: [projId] }));
+        dispatch(fetchProject(projId));
       }
     } catch (err) {
       console.log(`error attempting to delete tag: `, err);
@@ -890,11 +1020,9 @@ export const updateProjectTag = (payload) => {
       dispatch(updateProjectTagStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'updateProjectTag',
@@ -916,11 +1044,9 @@ export const createProjectLabel = (payload) => {
       dispatch(createProjectLabelStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'createProjectLabel',
@@ -941,11 +1067,9 @@ export const updateProjectLabel = (payload) => {
       dispatch(updateProjectLabelStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'updateProjectLabel',
@@ -966,11 +1090,9 @@ export const deleteProjectLabel = (payload) => {
       dispatch(deleteProjectLabelStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'deleteProjectLabel',
@@ -990,7 +1112,7 @@ export const deleteProjectLabel = (payload) => {
         } else {
           dispatch(deleteProjectLabelSuccess({ projId }));
           dispatch(clearImages());
-          dispatch(fetchProjects({ _ids: [projId] }));
+          dispatch(fetchProject(projId));
         }
       }
     } catch (err) {
@@ -1001,17 +1123,18 @@ export const deleteProjectLabel = (payload) => {
 };
 
 // Selectors
-export const selectProjects = (state) => state.projects.projects;
-export const selectSelectedProject = (state) =>
-  state.projects.projects.find((proj) => proj.selected);
-export const selectSelectedProjectId = createSelector([selectSelectedProject], (proj) =>
-  proj ? proj._id : null,
-);
+export const selectProjectStubs = (state) => state.projects.projectStubs;
+export const selectSelectedProject = (state) => state.projects.project;
+export const selectSelectedProjectId = (state) => state.projects.selectedProjectId;
+export const selectSelectedViewId = (state) => state.projects.selectedViewId;
+export const selectEditingProject = (state) => state.projects.editingProject;
+export const selectEditingProjectLoading = (state) => state.projects.loadingStates.editingProject;
 export const selectViews = createSelector([selectSelectedProject], (proj) =>
   proj ? proj.views : null,
 );
-export const selectSelectedView = createSelector([selectViews], (views) =>
-  views ? views.find((view) => view.selected) : null,
+export const selectSelectedView = createSelector(
+  [selectViews, selectSelectedViewId],
+  (views, viewId) => (views ? views.find((view) => view._id === viewId) : null),
 );
 export const selectUnsavedViewChanges = (state) => state.projects.unsavedViewChanges;
 export const selectMLModels = createSelector([selectSelectedProject], (proj) =>
@@ -1028,7 +1151,8 @@ export const selectProjectTags = createSelector([selectSelectedProject], (proj) 
 );
 export const selectProjectTagsLoading = (state) =>
   state.projects.loadingStates.projectTags.isLoading;
-export const selectProjectsLoading = (state) => state.projects.loadingStates.projects;
+export const selectProjectStubsLoading = (state) => state.projects.loadingStates.projectStubs;
+export const selectProjectLoading = (state) => state.projects.loadingStates.project;
 export const selectViewsLoading = (state) => state.projects.loadingStates.views;
 export const selectAutomationRulesLoading = (state) => state.projects.loadingStates.automationRules;
 export const selectModelsLoadingState = (state) => state.projects.loadingStates.models;
@@ -1036,7 +1160,8 @@ export const selectModalOpen = (state) => state.projects.modalOpen;
 export const selectModalContent = (state) => state.projects.modalContent;
 export const selectSelectedCamera = (state) => state.projects.selectedCamera;
 export const selectGlobalBreakpoint = (state) => state.projects.globalBreakpoint;
-export const selectProjectsErrors = (state) => state.projects.loadingStates.projects.errors;
+export const selectProjectStubsErrors = (state) => state.projects.loadingStates.projectStubs.errors;
+export const selectProjectErrors = (state) => state.projects.loadingStates.project.errors;
 export const selectViewsErrors = (state) => state.projects.loadingStates.views.errors;
 export const selectModelsErrors = (state) => state.projects.loadingStates.models.errors;
 export const selectCreateProjectsErrors = (state) =>

--- a/src/features/projects/usersSlice.js
+++ b/src/features/projects/usersSlice.js
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { Auth } from 'aws-amplify';
 import { call } from '../../api';
+import { selectSelectedProjectId } from './projectsSlice';
 
 const initialState = {
   users: [],
@@ -157,11 +158,9 @@ export const fetchUsers = () => {
 
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: 'getUsers',
@@ -181,11 +180,9 @@ export const updateUser = (values) => {
 
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         await call({
           projId,
           request: 'updateUser',
@@ -206,11 +203,9 @@ export const createUser = (values) => {
 
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const username = values.email.toLowerCase();
         await call({
           projId,
@@ -232,11 +227,9 @@ export const resendTempPassword = (values) => {
 
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         await call({
           projId,
           request: 'resendTempPassword',

--- a/src/features/review/reviewSlice.js
+++ b/src/features/review/reviewSlice.js
@@ -5,6 +5,7 @@ import { findImage, findObject, findLabel, isImageReviewed } from '../../app/uti
 import { enqueue } from './requestQueue';
 import { toggleOpenLoupe } from '../loupe/loupeSlice';
 import { getImagesSuccess, clearImages, deleteImagesSuccess } from '../images/imagesSlice';
+import { selectSelectedProjectId } from '../projects/projectsSlice';
 
 const initialState = {
   workingImages: [],
@@ -348,13 +349,12 @@ export const editLabel = (operation, entity, payload) => {
       await enqueue(async () => {
         const currentUser = await Auth.currentAuthenticatedUser();
         const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-        const projects = getState().projects.projects;
-        const selectedProj = projects.find((proj) => proj.selected);
+        const projId = selectSelectedProjectId(getState());
 
-        if (token && selectedProj) {
+        if (token && projId) {
           const req = operation + entity.charAt(0).toUpperCase() + entity.slice(1);
           await call({
-            projId: selectedProj._id,
+            projId,
             request: req,
             input: payload,
           });
@@ -385,13 +385,12 @@ export const editComment = (operation, payload) => {
       dispatch(editCommentStart(operation));
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const req = `${operation}ImageComment`;
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: req,
           input: payload,
         });
@@ -421,14 +420,13 @@ export const editTag = (operation, payload) => {
       await enqueue(async () => {
         const currentUser = await Auth.currentAuthenticatedUser();
         const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-        const projects = getState().projects.projects;
-        const selectedProj = projects.find((proj) => proj.selected);
+        const projId = selectSelectedProjectId(getState());
 
-        if (token && selectedProj) {
+        if (token && projId) {
           const req = `${operation}ImageTags`;
 
           await call({
-            projId: selectedProj._id,
+            projId,
             request: req,
             input: payload,
           });

--- a/src/features/tasks/tasksSlice.js
+++ b/src/features/tasks/tasksSlice.js
@@ -3,7 +3,8 @@ import { Auth } from 'aws-amplify';
 import { call } from '../../api';
 import { enrichCameraConfigs } from './utils';
 import {
-  fetchProjects,
+  fetchProject,
+  selectSelectedProjectId,
   setModalOpen,
   setModalContent,
   setSelectedCamera,
@@ -517,20 +518,22 @@ export const tasksSlice = createSlice({
 
       // GraphQL errors come in an array
       if (Array.isArray(payload)) {
-        ls.errors = payload.map(err => ({
+        ls.errors = payload.map((err) => ({
           message: err.message || 'An error occurred',
           extensions: {
-            code: err.extensions?.code || 'UNKNOWN_ERROR'
-          }
+            code: err.extensions?.code || 'UNKNOWN_ERROR',
+          },
         }));
       } else {
         // Single error case (network, auth issues, etc)
-        ls.errors = [{
-          message: error.message || error.toString(),
-          extensions: {
-            code: error.extensions?.code || error.code || 'UNKNOWN_ERROR'
-          }
-        }];
+        ls.errors = [
+          {
+            message: error.message || error.toString(),
+            extensions: {
+              code: error.extensions?.code || error.code || 'UNKNOWN_ERROR',
+            },
+          },
+        ];
       }
     },
 
@@ -628,7 +631,7 @@ export const {
   setTimestampOffsetFailure,
   clearSetTimestampOffsetTask,
   dismissSetTimestampOffsetError,
-  
+
   dismissTaskSuccessNotif,
 } = tasksSlice.actions;
 
@@ -638,12 +641,11 @@ export const fetchTask = (taskId) => {
     try {
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj && taskId) {
+      if (token && projId && taskId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'getTask',
           input: { taskId },
         });
@@ -685,7 +687,7 @@ export const fetchTask = (taskId) => {
                 const deploymentsLoadingState = getState().tasks.loadingStates.deployments;
                 dispatch(
                   editDeploymentsSuccess({
-                    projId: selectedProj._id,
+                    projId,
                     cameraConfig,
                     operation,
                     reqPayload: deploymentsLoadingState.reqPayload,
@@ -701,7 +703,7 @@ export const fetchTask = (taskId) => {
                 dispatch(setModalOpen(false));
                 dispatch(setModalContent(null));
                 dispatch(setSelectedCamera(null));
-                dispatch(fetchProjects({ _ids: [selectedProj._id] }));
+                dispatch(fetchProject(projId));
               },
               FAIL: (res) => dispatch(updateCameraSerialNumberFailure(res)),
             },
@@ -714,7 +716,7 @@ export const fetchTask = (taskId) => {
                 dispatch(setSelectedCamera(null));
                 dispatch(setDeleteCameraAlertStatus({ isOpen: false }));
                 dispatch(clearCameraImageCount());
-                dispatch(fetchProjects({ _ids: [selectedProj._id] }));
+                dispatch(fetchProject(projId));
               },
               FAIL: (res) => dispatch(updateDeleteCameraFailure(res)),
             },
@@ -755,7 +757,7 @@ export const fetchTask = (taskId) => {
               COMPLETE: (res) => {
                 dispatch(deleteProjectLabelTaskSuccess(res));
                 dispatch(clearImages());
-                dispatch(fetchProjects({ _ids: [selectedProj._id] }));
+                dispatch(fetchProject(projId));
               },
               FAIL: (res) => dispatch(deleteProjectLabelTaskFailure(res)),
             },
@@ -797,12 +799,11 @@ export const fetchStats = (filters) => {
       dispatch(getStatsStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'getStats',
           input: {
             filters,
@@ -823,12 +824,11 @@ export const fetchBurstsStats = (filters) => {
       dispatch(getBurstsStatsStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'getStats',
           input: {
             filters,
@@ -849,12 +849,11 @@ export const fetchIndependentDetectionStats = (filters, independenceInterval) =>
       dispatch(getIndependentDetectionStatsStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'getStats',
           input: {
             filters,
@@ -883,12 +882,11 @@ export const exportAnnotations = ({
       dispatch(exportAnnotationsStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'exportAnnotations',
           input: {
             format,
@@ -913,12 +911,11 @@ export const exportErrors = ({ filters }) => {
       dispatch(exportErrorsStart({ batch: filters.batch }));
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'exportErrors',
           input: { filters },
         });
@@ -942,11 +939,9 @@ export const editDeployments = (operation, payload) => {
       dispatch(editDeploymentsStart(payload));
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      const projId = selectedProj._id;
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
           projId,
           request: operation,
@@ -968,12 +963,11 @@ export const updateCameraSerialNumber = (payload) => {
       dispatch(updateCameraSerialNumberStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
-      if (token && selectedProj) {
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'updateCameraSerialNumber',
           input: payload,
         });
@@ -991,11 +985,10 @@ export const deleteCamera = (payload) => {
       dispatch(updateDeleteCameraStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      if (token && selectedProj) {
+      const projId = selectSelectedProjectId(getState());
+      if (token && projId) {
         const res = await call({
-          projId: selectedProj._id,
+          projId,
           request: 'deleteCameraConfig',
           input: payload,
         });
@@ -1019,19 +1012,18 @@ export const deleteImagesTask = ({ imageIds = [], filters = null }) => {
       dispatch(deleteImagesStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      if (token && selectedProj) {
+      const projId = selectSelectedProjectId(getState());
+      if (token && projId) {
         if (filters !== null) {
           const res = await call({
-            projId: selectedProj._id,
+            projId,
             request: 'deleteImagesByFilterTask',
             input: { filters },
           });
           dispatch(deleteImagesUpdate({ taskId: res.deleteImagesByFilterTask._id }));
         } else {
           const res = await call({
-            projId: selectedProj._id,
+            projId,
             request: 'deleteImagesTask',
             input: { imageIds },
           });
@@ -1057,19 +1049,18 @@ export const setTimestampOffsetTask = ({ imageIds = [], filters = null, offsetMs
       dispatch(setTimestampOffsetStart());
       const currentUser = await Auth.currentAuthenticatedUser();
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
-      if (token && selectedProj) {
+      const projId = selectSelectedProjectId(getState());
+      if (token && projId) {
         if (filters !== null) {
           const res = await call({
-            projId: selectedProj._id,
+            projId,
             request: 'setTimestampOffsetByFilterTask',
             input: { filters, offsetMs },
           });
           dispatch(setTimestampOffsetUpdate({ taskId: res.setTimestampOffsetByFilterTask._id }));
         } else {
           const res = await call({
-            projId: selectedProj._id,
+            projId,
             request: 'setTimestampOffsetBatchTask',
             input: { imageIds, offsetMs },
           });
@@ -1136,7 +1127,8 @@ export const selectBurstLevelStatsByDeployment = createSelector(
 
 export const selectDetectionsLevelStatsByDeployment = createSelector(
   [selectIndependentDetectionStats],
-  (independentDetectionStats) => independentDetectionStats?.detectionsLevelStatsByDeployment ?? null,
+  (independentDetectionStats) =>
+    independentDetectionStats?.detectionsLevelStatsByDeployment ?? null,
 );
 
 export default tasksSlice.reducer;

--- a/src/features/upload/uploadSlice.js
+++ b/src/features/upload/uploadSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { Auth } from 'aws-amplify';
 import { call } from '../../api';
-import { setSelectedProjAndView } from '../projects/projectsSlice';
+import { selectSelectedProjectId } from '../projects/projectsSlice';
 import { normalizeErrors } from '../../app/utils';
 
 const initialState = {
@@ -233,15 +233,6 @@ export const uploadSlice = createSlice({
       state.filter = payload;
     },
   },
-
-  extraReducers: (builder) => {
-    builder.addCase(setSelectedProjAndView, (state, { payload }) => {
-      if (payload.newProjSelected) {
-        // reset upload states
-        state = initialState;
-      }
-    });
-  },
 });
 
 export const {
@@ -275,8 +266,7 @@ export const uploadMultipartFile = (payload) => async (dispatch, getState) => {
       dispatch(uploadStart());
 
       const { file, overrideSerial } = payload;
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
       const chunkSizeInMB = 100;
       const chunkSize = 1024 * 1024 * chunkSizeInMB;
@@ -285,7 +275,7 @@ export const uploadMultipartFile = (payload) => async (dispatch, getState) => {
       // initialize multipart upload
       const initRes = await call({
         request: 'createUpload',
-        projId: selectedProj._id,
+        projId,
         input: {
           originalFile: file.name,
           partCount,
@@ -296,7 +286,7 @@ export const uploadMultipartFile = (payload) => async (dispatch, getState) => {
       if (overrideSerial.length) {
         await call({
           request: 'updateBatch',
-          projId: selectedProj._id,
+          projId,
           input: {
             _id: initRes.createUpload.batch,
             overrideSerial,
@@ -370,7 +360,7 @@ export const uploadMultipartFile = (payload) => async (dispatch, getState) => {
           uploadedParts.sort((a, b) => a.PartNumber - b.PartNumber);
           await call({
             request: 'closeUpload',
-            projId: selectedProj._id,
+            projId,
             input: {
               batchId: initRes.createUpload.batch,
               multipartUploadId: initRes.createUpload.multipartUploadId,
@@ -432,11 +422,10 @@ export const uploadFile = (payload) => async (dispatch, getState) => {
       dispatch(uploadStart());
 
       const { file, overrideSerial } = payload;
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
       const uploadUrl = await call({
         request: 'createUpload',
-        projId: selectedProj._id,
+        projId,
         input: {
           originalFile: file.name,
         },
@@ -447,7 +436,7 @@ export const uploadFile = (payload) => async (dispatch, getState) => {
       if (overrideSerial.length) {
         await call({
           request: 'updateBatch',
-          projId: selectedProj._id,
+          projId,
           input: {
             _id: uploadUrl.createUpload.batch,
             overrideSerial,
@@ -489,14 +478,13 @@ export const fetchBatches =
       const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
       if (token) {
         dispatch(fetchBatchesStart());
-        const projects = getState().projects.projects;
-        const selectedProj = projects.find((proj) => proj.selected);
+        const projId = selectSelectedProjectId(getState());
         const pageInfo = getState().uploads.pageInfo;
         const filter = getState().uploads.filter;
 
         const batches = await call({
           request: 'getBatches',
-          projId: selectedProj._id,
+          projId,
           input: { filter, pageInfo, page },
         });
 
@@ -514,12 +502,11 @@ export const stopBatch = (id) => async (dispatch, getState) => {
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
     if (token) {
       dispatch(stopBatchStart({ batch: id }));
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
       await call({
         request: 'stopBatch',
-        projId: selectedProj._id,
+        projId,
         input: { id },
       });
 
@@ -537,12 +524,11 @@ export const redriveBatch = (id) => async (dispatch, getState) => {
     const token = currentUser.getSignInUserSession().getIdToken().getJwtToken();
     if (token) {
       dispatch(redriveBatchStart({ batch: id }));
-      const projects = getState().projects.projects;
-      const selectedProj = projects.find((proj) => proj.selected);
+      const projId = selectSelectedProjectId(getState());
 
       await call({
         request: 'redriveBatch',
-        projId: selectedProj._id,
+        projId,
         input: { id },
       });
 


### PR DESCRIPTION
## Only fetch one Project at a time

Closes #371. Frontend-only — **no `animl-api` changes or coordinated deploy required.**

### Context

With SpeciesNet (~2500 classes), `getProjects` payloads grew large enough that superusers with access to ~70 Projects exceeded Lambda's 6 MB response limit. The [medium-term fix](https://github.com/tnc-ca-geo/animl-api/issues/358) bought headroom by splitting `automationRules` into its own query; this is the permanent fix.

A [previous attempt (#355)](https://github.com/tnc-ca-geo/animl-frontend/pull/355) was abandoned because reconciling the router with Redux state in `ProjectAndViewNav.jsx` became hard to reason about. This PR takes that on directly — the routing rewrite is the larger half of the change.

### What changed

**Two-tier Project data.** The app now fetches a lightweight *stub* for every accessible Project (`_id`, `name`, `description`, `views { _id name }`) and full detail only for the selected one. Both use the existing `projects(input: { _ids })` query with narrower GraphQL field selection, so there's no API change. Stubs are a few hundred bytes each, which puts 70 Projects well under 1% of the response limit.

**Explicit selection state.** `projectsSlice` moves from `projects[]` with client-side `selected: true` flags to:

```js
{ projectStubs, project, editingProject, selectedProjectId, selectedViewId, requestedProjectId }
```

Most consumers were unaffected because `selectSelectedProject`, `selectViews`, `selectProjectLabels`, `selectCameraConfigs` etc. were just redefined. A prep pass routed ~50 direct `projects.find(p => p.selected)` reads across 8 slices through selectors first, so the state reshape itself was a small diff.

**URL → Redux reconciliation moved into a listener.** New `src/features/projects/projectsListeners.js` runs a single linear pipeline on `LOCATION_CHANGE`:

> authenticated? → under `/app`? → stubs loaded? → resolve `projId` (`replace()` if missing/invalid) → resolve `viewId` (`replace()` if missing/invalid) → fetch detail if needed → commit selection → handle `?img=`

`ProjectAndViewNav.jsx` went from three interlocking `useEffect`s to zero and is now purely presentational. `enrichProjAndViewPayload` — which mutated action payloads in flight to inject `project`/`view`/`newProjSelected` — is deleted; `filtersSlice` now derives `availFilters` from `getProjectSuccess`, and `wirelessCamerasSlice` resets on a new `projectChanged` action. `setSelectedProjAndView` has exactly one dispatcher now (the listener), and `editView` navigates instead of dispatching selection directly.

**Superuser Edit Project form** uses a separate `editingProject` slice field fetched on demand, so editing a Project doesn't disturb the one you have open.

### Behaviour changes

Mostly none — the goal was to replicate existing UX. Two things are genuinely better:

- Invalid or inaccessible `projId`/`viewId` in the URL now fall back gracefully instead of throwing. The old code had a standing `// TODO: check that there are projects & views in state that match the Ids`.
- Creating or deleting a view now updates the URL, so shared links stay correct.

One fix that's independent of the refactor and could be pulled out if you'd rather review it separately: `diffFilters` compared filter id **arrays** with `_.isEqual`, but `checkboxFilterToggled` appends re-enabled ids to the end. Manually restoring a view's filters therefore left the "unsaved changes" indicator greyed out. It now sorts the four id categories before diffing. This only affects the comparison, not what gets saved.

### Notes for reviewers

**This app runs React 16 via `ReactDOM.render`.** React only auto-batches dispatches originating from its own event handlers and effect flushes. The listener effect runs in a promise microtask, so every related group of dispatches must be wrapped in `batch()` from react-redux. Without it, `ImagesPanel` fires `fetchImages` against half-applied state (new project id, previous view's filters) and stale responses dispatch `clearImages()`, which closes the Loupe via `focusIndex → null → ViewExplorer`. There's a comment on the listener explaining this — worth knowing before adding logic there.

Two other subtleties worth a look:

- `getOriginalState()` must be read synchronously at the top of the effect; RTK throws if called after an `await`.
- `projectChanged` deliberately leaves `state.project` in place until the new detail lands. Several components (`ExportModal`, `CategorySelector`, `BulkTagSelector`, `ShareImageButton`, `ImageReviewToolbar`, `AutomationRulesForm`) read the selected Project unguarded and would crash on `null`.

Slow `fetchProject` responses can no longer clobber a newer selection — `getProjectStart` records a `requestedProjectId` and the thunk bails if superseded. The guard is in the thunk rather than the reducer because `filtersSlice` derives `availFilters` from `getProjectSuccess` independently.

### Testing

No test runner is configured in this repo, so this was manually QA'd: single stub + single detail request on boot, superuser with ~70 Projects, cold-load of `/app/:projId/:viewId` and `?img=<id>` deep links, bare `/app` redirect, invalid ids, project/view switching, browser back/forward, view save/edit/delete, labels and tags modals, camera registration and deployment editing, superuser editing a non-selected Project, project creation, and bulk upload. `npm run build` and ESLint are clean.

### Follow-up (not in this PR)

The Redux store is never reset on sign-out — Amplify's `signOut` only triggers `userAuthStateChanged` + `clearUser`, and `clearUser` touches nothing outside the user slice. Cached Project data (labels, deployments, cameraConfigs) persists into the next user's session in the same tab. This is pre-existing and arguably slightly improved here, but it's worth a small follow-up adding a root-reducer reset on `authStatus === 'unauthenticated'`.