### PR TITLE
fix(488): reset Redux store on sign-out

### DIFF
--- a/src/app/rootReducer.js
+++ b/src/app/rootReducer.js
@@ -1,7 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import { connectRouter } from 'connected-react-router';
 import { undoHistoryReducer } from 'redux-undo-redo';
-import userReducer from '../features/user/userSlice';
+import userReducer, { userAuthStateChanged } from '../features/user/userSlice';
 import filtersReducer from '../features/filters/filtersSlice';
 import imagesReducer from '../features/images/imagesSlice';
 import wirelessCamerasReducer from '../features/cameras/wirelessCamerasSlice';
@@ -14,8 +14,8 @@ import uploadReducer from '../features/upload/uploadSlice';
 import tasksReducer from '../features/tasks/tasksSlice';
 import adminReducer from '../features/admin/adminSlice';
 
-const createRootReducer = (history) =>
-  combineReducers({
+const createRootReducer = (history) => {
+  const appReducer = combineReducers({
     router: connectRouter(history),
     user: userReducer,
     projects: projectReducer,
@@ -31,5 +31,18 @@ const createRootReducer = (history) =>
     tasks: tasksReducer,
     admin: adminReducer,
   });
+
+  // On sign-out, drop all cached state so nothing leaks into the next user's
+  // session (labels, deployments, cameraConfigs, projectStubs, etc.). Keep
+  // router state so connected-react-router stays in sync with the URL. Each
+  // slice reducer receives `undefined` and reinitializes itself, and this same
+  // action then sets the fresh user slice's authStatus to 'unauthenticated'.
+  return (state, action) => {
+    if (userAuthStateChanged.match(action) && action.payload.authStatus === 'unauthenticated') {
+      state = { router: state.router };
+    }
+    return appReducer(state, action);
+  };
+};
 
 export default createRootReducer;


### PR DESCRIPTION
## Description

Fixes #488.

Amplify's `signOut` only triggered `userAuthStateChanged` + `clearUser`, and neither touches anything outside the `user` slice. Cached project state (`labels`, `deployments`, `cameraConfigs`, `projectStubs`, images, filters, etc.) survived into the next user's session, so if user B signed in and landed on a project ID user A had open, the listener saw a matching `project._id`, skipped the fetch, and B saw A's cached data.

## Approach

The root-reducer intercept suggested in the issue: `createRootReducer` now wraps `combineReducers` and, when `userAuthStateChanged` fires with `authStatus: 'unauthenticated'`, drops all state except `router` (kept so connected-react-router stays in sync with the URL). Each slice reducer receives `undefined` and reinitializes itself, and the same action then flows into the fresh `user` slice and sets its `authStatus` to `'unauthenticated'` as before.

Two interactions I checked while implementing:

- `projectsListener` also matches `userAuthStateChanged`, but it early-returns when `authStatus !== 'authenticated'`, so the reset does not race it.
- The reset also fires on the initial `unauthenticated` dispatch at app boot, which is a no-op on a fresh store.

## Validation

- `npm run lint`: clean
- `npm run build`: succeeds (pre-existing chunk-size warnings only)
- Traced the sign-out flow in `App.jsx` → `userSlice` → `projectsListeners` to confirm ordering (reducers run before listener effects)
